### PR TITLE
Controllers: Return Proper HTTP Responses

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
@@ -26,70 +26,93 @@ public class ChatMessageController {
 
     // full path: /api/v1/chatMessages
     @GetMapping
-    public String getChatMessages() {
-        return "These are the chatMessages: " + chatMessageService.getAllChatMessages();
+    public ResponseEntity<List<ChatMessageDTO>> getChatMessages() {
+        try {
+            return new ResponseEntity<>(chatMessageService.getAllChatMessages(), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/chatMessages/{id}
     @GetMapping("/{id}")
-    public ChatMessageDTO getChatMessage(@PathVariable UUID id) {
-        return chatMessageService.getChatMessageById(id);
+    public ResponseEntity<ChatMessageDTO> getChatMessage(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(chatMessageService.getChatMessageById(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/chatMessages/mock-endpoint
     @GetMapping("/mock-endpoint")
-    public String getMockEndpoint() {
-        return "This is the mock endpoint for chatMessages. Everything is working with it.";
+    public ResponseEntity<String> getMockEndpoint() {
+        return new ResponseEntity<>("This is the mock endpoint for chatMessages. Everything is working with it.", HttpStatus.OK);
     }
 
     // full path: /api/v1/chatMessages
     @PostMapping
-    public ChatMessageDTO createChatMessage(@RequestBody ChatMessageDTO newChatMessage) {
-        return chatMessageService.saveChatMessage(newChatMessage);
-    }
-
-
-    // full path: /api/v1/chatMessages/{id}
-    @DeleteMapping("/{id}")
-    public ResponseEntity<HttpStatus> deleteChatMessage(@PathVariable UUID id) {
+    public ResponseEntity<ChatMessageDTO> createChatMessage(@RequestBody ChatMessageDTO newChatMessage) {
         try {
-            boolean isDeleted = chatMessageService.deleteChatMessageById(id);
-            if (isDeleted) {
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT); // Success
-            } else {
-                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Deletion failed
-            }
-        } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(chatMessageService.saveChatMessage(newChatMessage), HttpStatus.CREATED);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
-    // full path: /api/v1/chatMessages/{chatMessageId}/likes
+    // full path: /api/v1/chatMessages/{id}
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteChatMessage(@PathVariable UUID id) {
+        try {
+            boolean isDeleted = chatMessageService.deleteChatMessageById(id);
+            if (isDeleted) {
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            } else {
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+            }
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
     @PostMapping("/{chatMessageId}/likes/{userId}")
-    public ChatMessageLikesDTO createChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
-        return chatMessageService.createChatMessageLike(chatMessageId, userId);
+    public ResponseEntity<ChatMessageLikesDTO> createChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
+        try {
+            return new ResponseEntity<>(chatMessageService.createChatMessageLike(chatMessageId, userId), HttpStatus.CREATED);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/chatMessages/{chatMessageId}/likes
     @GetMapping("/{chatMessageId}/likes")
-    public List<UserDTO> getChatMessageLikes(@PathVariable UUID chatMessageId) {
-        return chatMessageService.getChatMessageLikes(chatMessageId);
+    public ResponseEntity<List<UserDTO>> getChatMessageLikes(@PathVariable UUID chatMessageId) {
+        try {
+            return new ResponseEntity<>(chatMessageService.getChatMessageLikes(chatMessageId), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
-    // full path: /api/v1/chatMessages/{chatMessageId}/likes
-    @DeleteMapping("/{chatMessageId}/likes")
+    // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
+    @DeleteMapping("/{chatMessageId}/likes/{userId}")
     public ResponseEntity<Void> deleteChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
         try {
             chatMessageService.deleteChatMessageLike(chatMessageId, userId);
-            return ResponseEntity.noContent().build(); // 204 success (no content)
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         } catch (BasesNotFoundException e) {
-            return ResponseEntity.notFound().build(); // 404
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().build(); // 500
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }
-
-

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -3,6 +3,7 @@ package com.danielagapov.spawn.Controllers;
 import com.danielagapov.spawn.DTOs.EventDTO;
 import com.danielagapov.spawn.DTOs.UserDTO;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
+import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
 import com.danielagapov.spawn.Services.Event.IEventService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,7 +27,7 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.getAllEvents(), HttpStatus.OK);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -36,9 +37,9 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.getEventById(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -50,7 +51,7 @@ public class EventController {
         } catch (BasesNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -60,7 +61,7 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.getEventsByTagId(tagId), HttpStatus.OK);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -76,7 +77,7 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.saveEvent(newEvent), HttpStatus.CREATED);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -86,9 +87,9 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.replaceEvent(newEvent, id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -103,9 +104,9 @@ public class EventController {
                 return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Deletion failed
             }
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -115,9 +116,9 @@ public class EventController {
         try {
             return new ResponseEntity<>(eventService.getParticipatingUsersByEventId(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -59,7 +59,7 @@ public class EventController {
     @GetMapping("friendTag/{tagId}")
     public ResponseEntity<List<EventDTO>> getEventsByFriendTagId(@PathVariable UUID tagId) {
         try {
-            return new ResponseEntity<>(eventService.getEventsByTagId(tagId), HttpStatus.OK);
+            return new ResponseEntity<>(eventService.getEventsByFriendTagId(tagId), HttpStatus.OK);
         } catch (BasesNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -60,6 +60,8 @@ public class EventController {
     public ResponseEntity<List<EventDTO>> getEventsByFriendTagId(@PathVariable UUID tagId) {
         try {
             return new ResponseEntity<>(eventService.getEventsByTagId(tagId), HttpStatus.OK);
+        } catch (BasesNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -47,6 +47,8 @@ public class EventController {
     public ResponseEntity<List<EventDTO>> getEventsByUserId(@PathVariable UUID userId) {
         try {
             return new ResponseEntity<>(eventService.getEventsByUserId(userId), HttpStatus.OK);
+        } catch (BasesNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 
 @RestController()
 @RequestMapping("api/v1/events")
-public class    EventController {
+public class EventController {
     private final IEventService eventService;
 
     public EventController(IEventService eventService) {
@@ -22,45 +22,72 @@ public class    EventController {
 
     // full path: /api/v1/events
     @GetMapping
-    public List<EventDTO> getEvents() {
-        return eventService.getAllEvents();
+    public ResponseEntity<List<EventDTO>> getEvents() {
+        try {
+            return new ResponseEntity<>(eventService.getAllEvents(), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 
     // full path: /api/v1/events/{id}
     @GetMapping("{id}")
-    public EventDTO getEvent(@PathVariable UUID id) {
-        return eventService.getEventById(id);
+    public ResponseEntity<EventDTO> getEvent(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(eventService.getEventById(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
-    
-    
+
     // full path: /api/v1/events/user/{userId}
     @GetMapping("user/{userId}")
-    public List<EventDTO> getEventsByUserId(@PathVariable UUID userId) {
-        return eventService.getEventsByUserId(userId);
+    public ResponseEntity<List<EventDTO>> getEventsByUserId(@PathVariable UUID userId) {
+        try {
+            return new ResponseEntity<>(eventService.getEventsByUserId(userId), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 
     // full path: /api/v1/events/friendTag/{tagId}
     @GetMapping("friendTag/{tagId}")
-    public List<EventDTO> getEventsByFriendTagId(@PathVariable UUID tagId) {
-        return eventService.getEventsByTagId(tagId);
+    public ResponseEntity<List<EventDTO>> getEventsByFriendTagId(@PathVariable UUID tagId) {
+        try {
+            return new ResponseEntity<>(eventService.getEventsByTagId(tagId), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 
     // full path: /api/v1/events/mock-endpoint
     @GetMapping("mock-endpoint")
-    public String getMockEndpoint() {
-        return "This is the mock endpoint for events. Everything is working with it.";
+    public ResponseEntity<String> getMockEndpoint() {
+        return new ResponseEntity<>("This is the mock endpoint for events. Everything is working with it.", HttpStatus.OK);
     }
 
     // full path: /api/v1/events
     @PostMapping
-    public EventDTO createEvent(@RequestBody EventDTO newEvent) {
-        return eventService.saveEvent(newEvent);
+    public ResponseEntity<EventDTO> createEvent(@RequestBody EventDTO newEvent) {
+        try {
+            return new ResponseEntity<>(eventService.saveEvent(newEvent), HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 
     // full path: /api/v1/events/{id}
     @PutMapping("{id}")
-    public EventDTO replaceEvent(@RequestBody EventDTO newEvent, @PathVariable UUID id) {
-        return eventService.replaceEvent(newEvent, id);
+    public ResponseEntity<EventDTO> replaceEvent(@RequestBody EventDTO newEvent, @PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(eventService.replaceEvent(newEvent, id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 
     // full path: /api/v1/events/{id}
@@ -82,7 +109,13 @@ public class    EventController {
 
     // full path: /api/v1/events/{id}/users
     @GetMapping("events/{id}/users")
-    public List<UserDTO> getUsersParticipatingInEvent(@PathVariable UUID id) {
-        return eventService.getParticipatingUsersByEventId(id);
+    public ResponseEntity<List<UserDTO>> getUsersParticipatingInEvent(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(eventService.getParticipatingUsersByEventId(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+        }
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -102,9 +102,8 @@ public class FriendTagController {
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (BaseSaveException e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
+            // this also catches `BaseSaveException`, which we're treating the same way with a 500 error below
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -11,9 +11,10 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.UUID;
 
-@RestController()
+@RestController
 @RequestMapping("api/v1/friendTags")
 public class FriendTagController {
+
     private final IFriendTagService friendTagService;
 
     public FriendTagController(IFriendTagService friendTagService) {
@@ -22,32 +23,58 @@ public class FriendTagController {
 
     // full path: /api/v1/friendTags
     @GetMapping
-    public List<FriendTagDTO> getFriendTags() {
-        return friendTagService.getAllFriendTags();
+    public ResponseEntity<List<FriendTagDTO>> getFriendTags() {
+        try {
+            return new ResponseEntity<>(friendTagService.getAllFriendTags(), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/friendTags/{id}
     @GetMapping("{id}")
-    public FriendTagDTO getFriendTag(@PathVariable UUID id) {
-        return friendTagService.getFriendTagById(id);
+    public ResponseEntity<FriendTagDTO> getFriendTag(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(friendTagService.getFriendTagById(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/friendTags/mock-endpoint
     @GetMapping("mock-endpoint")
-    public String getMockEndpoint() {
-        return "This is the mock endpoint for friendTags. Everything is working with it.";
+    public ResponseEntity<String> getMockEndpoint() {
+        try {
+            return new ResponseEntity<>("This is the mock endpoint for friendTags. Everything is working with it.", HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/friendTags
     @PostMapping
-    public FriendTagDTO createFriendTag(@RequestBody FriendTagDTO newFriendTag) {
-        return friendTagService.saveFriendTag(newFriendTag);
+    public ResponseEntity<FriendTagDTO> createFriendTag(@RequestBody FriendTagDTO newFriendTag) {
+        try {
+            return new ResponseEntity<>(friendTagService.saveFriendTag(newFriendTag), HttpStatus.CREATED);
+        } catch (BaseSaveException e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/friendTags/{id}
     @PutMapping("{id}")
-    public FriendTagDTO replaceFriendTag(@RequestBody FriendTagDTO newFriendTag, @PathVariable UUID id) {
-        return friendTagService.replaceFriendTag(newFriendTag, id);
+    public ResponseEntity<FriendTagDTO> replaceFriendTag(@RequestBody FriendTagDTO newFriendTag, @PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(friendTagService.replaceFriendTag(newFriendTag, id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/friendTags/{id}
@@ -56,14 +83,14 @@ public class FriendTagController {
         try {
             boolean isDeleted = friendTagService.deleteFriendTagById(id);
             if (isDeleted) {
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT); // Success
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             } else {
-                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Deletion failed
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -72,20 +99,13 @@ public class FriendTagController {
     public ResponseEntity<Void> addUserToFriendTag(@PathVariable UUID id, @RequestParam UUID userId) {
         try {
             friendTagService.saveUserToFriendTag(id, userId);
+            return new ResponseEntity<>(HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 404
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (BaseSaveException e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // 500 TODO consider updating this
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // 500
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<>(HttpStatus.OK); //200
     }
 }
-
-
-
-
-
-
-

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -25,44 +25,80 @@ public class UserController {
 
     // full path: /api/v1/users
     @GetMapping
-    public List<UserDTO> getUsers() {
-        return userService.getAllUsers();
+    public ResponseEntity<List<UserDTO>> getUsers() {
+        try {
+            return new ResponseEntity<>(userService.getAllUsers(), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}
     @GetMapping("{id}")
-    public UserDTO getUser(@PathVariable UUID id) {
-        return userService.getUserById(id);
+    public ResponseEntity<UserDTO> getUser(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(userService.getUserById(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}/friends
     @GetMapping("{id}/friends")
-    public List<UserDTO> getUserFriends(@PathVariable UUID id) {
-        return userService.getFriendsByUserId(id);
+    public ResponseEntity<List<UserDTO>> getUserFriends(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(userService.getFriendsByUserId(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/mock-endpoint
     @GetMapping("mock-endpoint")
-    public String getMockEndpoint() {
-        return "This is the mock endpoint for users. Everything is working with it.";
+    public ResponseEntity<String> getMockEndpoint() {
+        try {
+            return new ResponseEntity<>("This is the mock endpoint for users. Everything is working with it.", HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/friendtag/{tagId}
     @GetMapping("/friendTag/{tagId}")
-    public List<UserDTO> getUsersByFriendTag(@PathVariable UUID tagId) {
-        return userService.getUsersByTagId(tagId);
+    public ResponseEntity<List<UserDTO>> getUsersByFriendTag(@PathVariable UUID tagId) {
+        try {
+            return new ResponseEntity<>(userService.getUsersByTagId(tagId), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users
     @PostMapping
-    public UserDTO createUser(@RequestBody UserDTO newUser) {
-        return userService.saveUser(newUser);
+    public ResponseEntity<UserDTO> createUser(@RequestBody UserDTO newUser) {
+        try {
+            return new ResponseEntity<>(userService.saveUser(newUser), HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}
     @PutMapping("{id}")
-    public UserDTO replaceUser(@RequestBody UserDTO newUser, @PathVariable UUID id) {
-        return userService.replaceUser(newUser, id);
+    public ResponseEntity<UserDTO> replaceUser(@RequestBody UserDTO newUser, @PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(userService.replaceUser(newUser, id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}
@@ -71,27 +107,37 @@ public class UserController {
         try {
             boolean isDeleted = userService.deleteUserById(id);
             if (isDeleted) {
-                return new ResponseEntity<>(HttpStatus.NO_CONTENT); // Success
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
             } else {
-                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Deletion failed
+                return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
             }
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // Resource not found
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // Unexpected error
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
     // full path: /api/v1/users/friend-request
     @PostMapping("friend-request")
-    public FriendRequestDTO createFriendRequest(@RequestBody FriendRequestDTO friendReq) {
-        return friendRequestService.saveFriendRequest(friendReq);
+    public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendReq) {
+        try {
+            return new ResponseEntity<>(friendRequestService.saveFriendRequest(friendReq), HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}/friend-requests
     @GetMapping("{id}/friend-requests")
-    public List<FriendRequestDTO> getIncomingFriendRequests(@PathVariable UUID id) {
-        return friendRequestService.getIncomingFriendRequestsByUserId(id);
+    public ResponseEntity<List<FriendRequestDTO>> getIncomingFriendRequests(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(friendRequestService.getIncomingFriendRequestsByUserId(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 
     // full path: /api/v1/users/{id}/removeFriend?friendId=friendId
@@ -99,17 +145,23 @@ public class UserController {
     public ResponseEntity<Void> deleteFriendFromUser(@PathVariable UUID id, @RequestParam UUID friendId) {
         try {
             userService.removeFriend(id, friendId);
+            return new ResponseEntity<>(HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND); // 404
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR); // 500
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
-        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     // full path: /api/v1/users/{id}/recommended-friends
     @GetMapping("{id}/recommended-friends")
-    public List<UserDTO> getRecommendedFriends(@PathVariable UUID id) {
-        return userService.getRecommendedFriends(id);
+    public ResponseEntity<List<UserDTO>> getRecommendedFriends(@PathVariable UUID id) {
+        try {
+            return new ResponseEntity<>(userService.getRecommendedFriends(id), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Repositories/IEventRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IEventRepository.java
@@ -4,9 +4,16 @@ import com.danielagapov.spawn.Models.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface IEventRepository extends JpaRepository<Event, UUID> {
-    // The JpaRepository interface already includes methods like save() and findById()
+    // JPA (Java Persistence API) should automatically create queries based on these method names:
+
+    // finds events that have been created by a user, by their `creatorId`
+    List<Event> findByCreatorId(UUID creatorId);
+
+    // finds events that have been created by users, whose ids are in the `creatorIds` list
+    List<Event> findByCreatorIdIn(List<UUID> creatorIds);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -46,7 +46,7 @@ public class EventService implements IEventService {
                 .orElseThrow(() -> new BaseNotFoundException(EntityType.Event, id)));
     }
 
-    public List<EventDTO> getEventsByTagId(UUID tagId) {
+    public List<EventDTO> getEventsByFriendTagId(UUID tagId) {
         try {
             // Step 1: Get the FriendTag and associated friends
             FriendTagDTO friendTag = friendTagService.getFriendTagById(tagId);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class EventService implements IEventService {
@@ -77,8 +78,16 @@ public class EventService implements IEventService {
     }
 
     public List<EventDTO> getEventsByUserId(UUID userId) {
-        // TODO: Add proper filtering logic for events by user
-        return EventMapper.toDTOList(repository.findAll());
+        List<Event> events = repository.findAll()
+                .stream()
+                .filter(event -> event.getCreator().getId().equals(userId))
+                .collect(Collectors.toList());
+
+        if (events.isEmpty()) {
+            throw new BasesNotFoundException(EntityType.Event);
+        }
+
+        return EventMapper.toDTOList(events);
     }
 
     public EventDTO replaceEvent(EventDTO newEvent, UUID id) {

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -53,7 +53,7 @@ public class EventService implements IEventService {
             List<UserDTO> friends = friendTag.friends();
 
             if (friends.isEmpty()) {
-                throw new BasesNotFoundException(EntityType.User);
+                return List.of();
             }
 
             // Step 2: Collect all friend user IDs

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface IEventService {
     public List<EventDTO> getAllEvents();
     public EventDTO getEventById(UUID id);
-    public List<EventDTO> getEventsByTagId(UUID tagId);
+    public List<EventDTO> getEventsByTagId(UUID friendTagId);
     public EventDTO saveEvent(EventDTO event);
     public List<EventDTO> getEventsByUserId(UUID userId);
     public EventDTO replaceEvent(EventDTO event, UUID eventId);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -9,7 +9,7 @@ import java.util.UUID;
 public interface IEventService {
     public List<EventDTO> getAllEvents();
     public EventDTO getEventById(UUID id);
-    public List<EventDTO> getEventsByTagId(UUID friendTagId);
+    public List<EventDTO> getEventsByFriendTagId(UUID friendTagId);
     public EventDTO saveEvent(EventDTO event);
     public List<EventDTO> getEventsByUserId(UUID userId);
     public EventDTO replaceEvent(EventDTO event, UUID eventId);


### PR DESCRIPTION
#59 

Simple PR, just doing what's been done to a few endpoints with http response codes to all of them for consistency, and so the mobile side can error-handle more effectively.

- Also, implemented the following methods in `EventService.java` properly: `getEventsByTagId()` & `getEventsByUserId()`

For our controller classes, I’ve just realized we should be returning 200 status codes (HttpStatus.OK) instead of 404 (HttpStatus.NOT_FOUND), based on this answer: https://stackoverflow.com/a/13367198/13368695.

This doesn’t require any changes to how we’re throwing BaseNotFoundException and BasesNotFoundException in our service class layer, so don’t worry about that. It’s just that from those errors, we need to return a different status code, as I’ll adjust for in my current PR, Controllers: Return Proper HTTP Responses #79