### PR TITLE
`FullEventDTO`: including color & `ParticipationStatus` + returning from  new `invitedEvents` endpoint

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -33,7 +33,7 @@ public class EventController {
         }
     }
 
-    // full path: /api/v1/events/{id}?full=full
+    // full path: /api/v1/events/{id}?full=full&requestingUserId=requestingUserId
     @GetMapping("{id}")
     public ResponseEntity<IEventDTO> getEventById(@PathVariable UUID id, @RequestParam boolean full, @RequestParam UUID requestingUserId) {
         try {
@@ -180,7 +180,7 @@ public class EventController {
         }
     }
 
-    // full path: /api/v1/events/{userId}/invitedEvents
+    // full path: /api/v1/events/{userId}/invitedEvents?full=true
     @GetMapping("{userId}/invitedEvents")
     // need this `? extends IEventDTO` instead of simply `IEventDTO`, because of this error:
     // https://stackoverflow.com/questions/27522741/incompatible-types-inference-variable-t-has-incompatible-bounds

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -37,7 +37,7 @@ public class EventController {
     @GetMapping("{id}")
     public ResponseEntity<IEventDTO> getEventById(@PathVariable UUID id, @RequestParam boolean full, @RequestParam UUID requestingUserId) {
         try {
-            if (full) {
+            if (full && requestingUserId != null) {
                 return new ResponseEntity<>(eventService.getFullEventById(id, requestingUserId), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(eventService.getEventById(id), HttpStatus.OK);
@@ -182,9 +182,15 @@ public class EventController {
 
     // full path: /api/v1/events/{userId}/invitedEvents
     @GetMapping("{userId}/invitedEvents")
-    public ResponseEntity<List<EventDTO>>getEventsInvitedTo(@PathVariable UUID id) {
+    // need this `? extends IEventDTO` instead of simply `IEventDTO`, because of this error:
+    //
+    public ResponseEntity<List<? extends IEventDTO>>getEventsInvitedTo(@PathVariable UUID userId, @RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(eventService.getEventsInvitedTo(id), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(eventService.getFullEventsInvitedTo(userId), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(eventService.getEventsInvitedTo(userId), HttpStatus.OK);
+            }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -183,7 +183,7 @@ public class EventController {
     // full path: /api/v1/events/{userId}/invitedEvents
     @GetMapping("{userId}/invitedEvents")
     // need this `? extends IEventDTO` instead of simply `IEventDTO`, because of this error:
-    //
+    // https://stackoverflow.com/questions/27522741/incompatible-types-inference-variable-t-has-incompatible-bounds
     public ResponseEntity<List<? extends IEventDTO>>getEventsInvitedTo(@PathVariable UUID userId, @RequestParam boolean full) {
         try {
             if (full) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -180,7 +180,7 @@ public class EventController {
         }
     }
 
-    // full path: /api/v1/events/{userId}/invitedEvents?full=true
+    // full path: /api/v1/events/{userId}/invitedEvents?full=full
     @GetMapping("{userId}/invitedEvents")
     // need this `? extends IEventDTO` instead of simply `IEventDTO`, because of this error:
     // https://stackoverflow.com/questions/27522741/incompatible-types-inference-variable-t-has-incompatible-bounds

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -1,7 +1,6 @@
 package com.danielagapov.spawn.Controllers;
 
 import com.danielagapov.spawn.DTOs.EventDTO;
-import com.danielagapov.spawn.DTOs.FullEventDTO;
 import com.danielagapov.spawn.DTOs.IEventDTO;
 import com.danielagapov.spawn.DTOs.UserDTO;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
@@ -36,10 +35,10 @@ public class EventController {
 
     // full path: /api/v1/events/{id}?full=full
     @GetMapping("{id}")
-    public ResponseEntity<IEventDTO> getEventById(@PathVariable UUID id, @RequestParam boolean full) {
+    public ResponseEntity<IEventDTO> getEventById(@PathVariable UUID id, @RequestParam boolean full, @RequestParam UUID requestingUserId) {
         try {
             if (full) {
-                return new ResponseEntity<>(eventService.getFullEventById(id), HttpStatus.OK);
+                return new ResponseEntity<>(eventService.getFullEventById(id, requestingUserId), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(eventService.getEventById(id), HttpStatus.OK);
             }

--- a/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
@@ -1,14 +1,12 @@
 package com.danielagapov.spawn.DTOs;
 
 
-import com.danielagapov.spawn.Models.Location;
-
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
-public record FullEventDTO(
+public record FullFeedEventDTO(
         UUID id,
         String title,
         OffsetDateTime startTime,
@@ -18,5 +16,7 @@ public record FullEventDTO(
         UserDTO creatorUser,
         List<UserDTO> participantUsers,
         List<UserDTO> invitedUsers,
-        List<ChatMessageDTO> chatMessages
+        List<ChatMessageDTO> chatMessages,
+        /// useful for event retrieval from a user's feed/map view on mobile:
+        String eventFriendTagColorHexCodeForRequestingUser
 ) implements Serializable, IEventDTO {}

--- a/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
@@ -2,6 +2,7 @@ package com.danielagapov.spawn.DTOs;
 
 
 import com.danielagapov.spawn.Enums.ParticipationStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
@@ -21,5 +22,6 @@ public record FullFeedEventDTO(
         List<ChatMessageDTO> chatMessages,
         /// useful for event retrieval from a user's feed/map view on mobile:
         String eventFriendTagColorHexCodeForRequestingUser,
-        ParticipationStatus participationStatus
+        // ensures string formatting when serialized to JSON, for mobile (client)
+        @JsonFormat(shape = JsonFormat.Shape.STRING) ParticipationStatus participationStatus
 ) implements Serializable, IEventDTO {}

--- a/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/FullFeedEventDTO.java
@@ -1,6 +1,8 @@
 package com.danielagapov.spawn.DTOs;
 
 
+import com.danielagapov.spawn.Enums.ParticipationStatus;
+
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -18,5 +20,6 @@ public record FullFeedEventDTO(
         List<UserDTO> invitedUsers,
         List<ChatMessageDTO> chatMessages,
         /// useful for event retrieval from a user's feed/map view on mobile:
-        String eventFriendTagColorHexCodeForRequestingUser
+        String eventFriendTagColorHexCodeForRequestingUser,
+        ParticipationStatus participationStatus
 ) implements Serializable, IEventDTO {}

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -365,15 +365,15 @@ public class EventService implements IEventService {
 
     public String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId) {
         // get event creator from eventDTO
-        friendTagService.getFriendTagFriendPartOfByOwnerUserId(requestingUserId, eventDTO.creatorUserId());
 
         // use creator to get the friend tag that relates the requesting user to see
         // which friend tag they've placed them in
+        FriendTagDTO pertainingFriendTag = friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.creatorUserId());
 
-        // -> for now, handle tie-breaks (user has same friend within two friend tags) in whichever way (just choose one)
+        // -> for now, we handle tie-breaks (user has same friend within two friend tags) in whichever way (just choose one)
 
         // using that friend tag, grab its colorHexCode property to return from this method
 
-        return "";
+        return pertainingFriendTag.colorHexCode();
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -24,8 +24,6 @@ import com.danielagapov.spawn.Services.User.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.dao.DataAccessException;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -86,8 +84,6 @@ public class EventService implements IEventService {
         return EventMapper.toDTO(event, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
     }
 
-    public FullEventDTO getFullEventById(UUID id) {
-        return getFullEventByEvent(getEventById(id));
     public FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId) {
         return getFullEventByEvent(getEventById(id), requestingUserId);
     }
@@ -351,8 +347,6 @@ public class EventService implements IEventService {
         return getEventDTOS(events);
     }
 
-    public FullEventDTO getFullEventByEvent(EventDTO event) {
-        return new FullEventDTO(
     public FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId) {
         return new FullFeedEventDTO(
                 event.id(),
@@ -364,9 +358,22 @@ public class EventService implements IEventService {
                 userService.getUserById(event.creatorUserId()),
                 userService.getParticipantsByEventId(event.id()),
                 userService.getInvitedByEventId(event.id()),
-                chatMessageService.getChatMessagesByEventId(event.id())
                 chatMessageService.getChatMessagesByEventId(event.id()),
                 getFriendTagColorHexCodeForRequestingUser(event, requestingUserId)
         );
+    }
+
+    public String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId) {
+        // get event creator from eventDTO
+        friendTagService.getFriendTagFriendPartOfByOwnerUserId(requestingUserId, eventDTO.creatorUserId());
+
+        // use creator to get the friend tag that relates the requesting user to see
+        // which friend tag they've placed them in
+
+        // -> for now, handle tie-breaks (user has same friend within two friend tags) in whichever way (just choose one)
+
+        // using that friend tag, grab its colorHexCode property to return from this method
+
+        return "";
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -88,6 +88,8 @@ public class EventService implements IEventService {
 
     public FullEventDTO getFullEventById(UUID id) {
         return getFullEventByEvent(getEventById(id));
+    public FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId) {
+        return getFullEventByEvent(getEventById(id), requestingUserId);
     }
 
     public List<EventDTO> getEventsByFriendTagId(UUID tagId) {
@@ -351,6 +353,8 @@ public class EventService implements IEventService {
 
     public FullEventDTO getFullEventByEvent(EventDTO event) {
         return new FullEventDTO(
+    public FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId) {
+        return new FullFeedEventDTO(
                 event.id(),
                 event.title(),
                 event.startTime(),
@@ -361,6 +365,8 @@ public class EventService implements IEventService {
                 userService.getParticipantsByEventId(event.id()),
                 userService.getInvitedByEventId(event.id()),
                 chatMessageService.getChatMessagesByEventId(event.id())
+                chatMessageService.getChatMessagesByEventId(event.id()),
+                getFriendTagColorHexCodeForRequestingUser(event, requestingUserId)
         );
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -380,7 +380,8 @@ public class EventService implements IEventService {
                 userService.getParticipantsByEventId(event.id()),
                 userService.getInvitedByEventId(event.id()),
                 chatMessageService.getChatMessagesByEventId(event.id()),
-                getFriendTagColorHexCodeForRequestingUser(event, requestingUserId)
+                getFriendTagColorHexCodeForRequestingUser(event, requestingUserId),
+                getParticipationStatus(event.id(), requestingUserId)
         );
     }
 

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -347,6 +347,30 @@ public class EventService implements IEventService {
         return getEventDTOS(events);
     }
 
+    public List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id) {
+        List<EventUser> eventUsers = eventUserRepository.findByUser_Id(id);
+
+        List<Event> events = new ArrayList<>();
+
+        if (eventUsers.isEmpty()) {
+            // throws no user found exception
+            throw new BaseNotFoundException(EntityType.User, id);
+        }
+
+        for (EventUser eventUser : eventUsers) {
+            if (eventUser.getUser().getId().equals(id)) {
+                events.add(eventUser.getEvent());
+            }
+        }
+
+        List<EventDTO> eventDTOs = getEventDTOS(events);
+
+        // Transform each EventDTO into a FullFeedEventDTO
+        return eventDTOs.stream()
+                .map(eventDTO -> getFullEventByEvent(eventDTO, id))
+                .toList();
+    }
+
     public FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId) {
         return new FullFeedEventDTO(
                 event.id(),

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -202,14 +202,7 @@ public class EventService implements IEventService {
             // Save updated event
             repository.save(event);
 
-            // Fetch related data for DTO
-            UUID creatorUserId = event.getCreator().getId();
-            List<UUID> participantUserIds = userService.getParticipantUserIdsByEventId(event.getId());
-            List<UUID> invitedUserIds = userService.getInvitedUserIdsByEventId(event.getId());
-            List<UUID> chatMessageIds = chatMessageService.getChatMessageIdsByEventId(event.getId());
-
-            // Convert updated event to DTO
-            return EventMapper.toDTO(event, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
+            return constructDTOFromEntity(event);
         }).orElseGet(() -> {
             // Map and save new event, fetch location and creator
             Location location = LocationMapper.toEntity(locationService.getLocationById(newEvent.locationId()));
@@ -219,15 +212,19 @@ public class EventService implements IEventService {
             Event eventEntity = EventMapper.toEntity(newEvent, location, creator);
             repository.save(eventEntity);
 
-            // Fetch related data for DTO
-            UUID creatorUserId = eventEntity.getCreator().getId();
-            List<UUID> participantUserIds = userService.getParticipantUserIdsByEventId(eventEntity.getId());
-            List<UUID> invitedUserIds = userService.getInvitedUserIdsByEventId(eventEntity.getId());
-            List<UUID> chatMessageIds = chatMessageService.getChatMessageIdsByEventId(eventEntity.getId());
-
-            // Return DTO after entity creation
-            return EventMapper.toDTO(eventEntity, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
+            return constructDTOFromEntity(eventEntity);
         });
+    }
+
+    private EventDTO constructDTOFromEntity(Event eventEntity) {
+        // Fetch related data for DTO
+        UUID creatorUserId = eventEntity.getCreator().getId();
+        List<UUID> participantUserIds = userService.getParticipantUserIdsByEventId(eventEntity.getId());
+        List<UUID> invitedUserIds = userService.getInvitedUserIdsByEventId(eventEntity.getId());
+        List<UUID> chatMessageIds = chatMessageService.getChatMessageIdsByEventId(eventEntity.getId());
+
+        // Return DTO after entity creation
+        return EventMapper.toDTO(eventEntity, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
     }
 
     public boolean deleteEventById(UUID id) {

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -1,7 +1,7 @@
 package com.danielagapov.spawn.Services.Event;
 
 import com.danielagapov.spawn.DTOs.EventDTO;
-import com.danielagapov.spawn.DTOs.FullEventDTO;
+import com.danielagapov.spawn.DTOs.FullFeedEventDTO;
 import com.danielagapov.spawn.DTOs.UserDTO;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
 
@@ -11,7 +11,7 @@ import java.util.UUID;
 public interface IEventService {
     List<EventDTO> getAllEvents();
     EventDTO getEventById(UUID id);
-    FullEventDTO getFullEventById(UUID id);
+    FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId);
     List<EventDTO> getEventsByFriendTagId(UUID friendTagId);
     EventDTO saveEvent(EventDTO event);
     List<EventDTO> getEventsByUserId(UUID userId);
@@ -22,5 +22,6 @@ public interface IEventService {
     boolean inviteUser(UUID eventId, UUID userId);
     boolean toggleParticipation(UUID eventId, UUID userId);
     List<EventDTO> getEventsInvitedTo(UUID id);
-    FullEventDTO getFullEventByEvent(EventDTO event);
+    FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId);
+    String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -22,6 +22,7 @@ public interface IEventService {
     boolean inviteUser(UUID eventId, UUID userId);
     boolean toggleParticipation(UUID eventId, UUID userId);
     List<EventDTO> getEventsInvitedTo(UUID id);
+    List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id);
     FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId);
     String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -183,7 +183,7 @@ public class FriendTagService implements IFriendTagService {
     /// it will return precisely one of the friend tags that the owner has placed this
     /// friend inside, even if they've placed them in multiple friend tags
     /// -> currently, on the product side, we don't specify a rule for which should take precedence.
-    public FriendTagDTO getFriendTagFriendPartOfByOwnerUserId(UUID ownerUserId, UUID friendUserId) {
+    public FriendTagDTO getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId) {
         // Fetch all friend tags for the owner
         return getFriendTagsByOwnerId(ownerUserId).stream()
                 // Filter to include only friend tags where friendUserId exists in friendUserIds

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -178,4 +178,19 @@ public class FriendTagService implements IFriendTagService {
                 friendTag.friendUserIds().stream().map(userService::getUserById).collect(Collectors.toList()),
                 friendTag.isEveryone());
     }
+
+    /// this function takes the owner user id of a friend tag, and the friend's user id
+    /// it will return precisely one of the friend tags that the owner has placed this
+    /// friend inside, even if they've placed them in multiple friend tags
+    /// -> currently, on the product side, we don't specify a rule for which should take precedence.
+    public FriendTagDTO getFriendTagFriendPartOfByOwnerUserId(UUID ownerUserId, UUID friendUserId) {
+        // Fetch all friend tags for the owner
+        return getFriendTagsByOwnerId(ownerUserId).stream()
+                // Filter to include only friend tags where friendUserId exists in friendUserIds
+                .filter(friendTag -> friendTag.friendUserIds().contains(friendUserId))
+                // Return the first matching friend tag, or throw an exception if none is found
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No friend tag found containing the specified friendUserId."));
+    }
+
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
@@ -18,5 +18,5 @@ public interface IFriendTagService {
     void saveUserToFriendTag(UUID id, UUID userId);
     List<UUID> getFriendTagIdsByOwnerUserId(UUID id);
     FullFriendTagDTO getFullFriendTagByFriendTag(FriendTagDTO friendTag);
-    FriendTagDTO getFriendTagFriendPartOfByOwnerUserId(UUID ownerUserId, UUID friendUserId);
+    FriendTagDTO getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
@@ -18,4 +18,5 @@ public interface IFriendTagService {
     void saveUserToFriendTag(UUID id, UUID userId);
     List<UUID> getFriendTagIdsByOwnerUserId(UUID id);
     FullFriendTagDTO getFullFriendTagByFriendTag(FriendTagDTO friendTag);
+    FriendTagDTO getFriendTagFriendPartOfByOwnerUserId(UUID ownerUserId, UUID friendUserId);
 }


### PR DESCRIPTION
#105 

Feel free to comment on anything, from naming to logic. I'm open to suggestions. 

- Rename `FullEventDTO` -> `FullFeedEventDTO` to convey purpose on mobile side of loading in feed
    - added color hex code property, as per #105 
        - Implemented its logic for retrieval in new methods: `getFriendTagColorHexCodeForRequestingUser()` & `getPertainingFriendTagByUserIds()`
- Returned `FullFeedEventDTO` from `invitedEvents` endpoint with same `full` request param as @SeabertYuan used in #100 
- Created helper method `constructDTOFromEntity(Event eventEntity)` for duplicate code fragment