### PR TITLE
OAuth: Documentation and var name changes

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
@@ -20,8 +20,15 @@ public class OAuthController {
         this.oauthService = oauthService;
     }
 
+    /**
+     * 
+     * @param principal the google oauth response
+     * @return either a `UserDTO` if they're verified to already have been a Spawn user, or
+     * a newly-created user if they weren't previously a Spawn user
+     */
     // full path: /api/v1/oauth/google/sign-in
     @RequestMapping("google/sign-in")
+    @Deprecated(since = "We no longer use this to sign in, since our authentication is done through mobile")
     public ResponseEntity<AbstractUserDTO> googleSignIn(@AuthenticationPrincipal OAuth2User principal) {
         try {
             AbstractUserDTO verifiedUserDTO = oauthService.verifyUser(principal);
@@ -31,20 +38,40 @@ public class OAuthController {
         }
     }
 
-    // full path: /api/v1/oauth/sign-in?sub=su
-    @GetMapping("sign-in?sub=sub")
-    public ResponseEntity<FullUserDTO> signIn(@RequestParam("sub") String sub) {
+    /**
+     * This method is meant to check whether an externally signed-in user through either Google or Apple
+     * already has an existing `User` created within spawn, given their external user id, which we check 
+     * against our mappings of internal ids to external ones. 
+     * 
+     * If the user is already saved within Spawn -> we return its `FullUserDTO`. Otherwise, null.
+     */
+    // full path: /api/v1/oauth/sign-in?externalUserId=externalUserId
+    @GetMapping("sign-in")
+    public ResponseEntity<FullUserDTO> signIn(@RequestParam("externalUserId") String externalUserId) {
         try {
-            return ResponseEntity.ok().body(oauthService.getUserIfExistsbyExternalId(sub));
+            return ResponseEntity.ok().body(oauthService.getUserIfExistsbyExternalId(externalUserId));
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(null);
         }
     }
 
+    /**
+     * This method creates a user, given a `UserDTO` from mobile, which can be constructed through the email 
+     * given through Google, Apple, or email/pass authentication + attributes input either by default through 
+     * these providers, such as full name & pfp, or supplied by the user (i.e. overwritten by provider, or new).
+     * 
+     * For profile pictures specifically, there's an optional argument, `profilePicture`, which will take a raw 
+     * byte file to overwrite/write the profile picture to the user, by saving it to the S3Service
+     * 
+     * Another argument is the `externalUserId`, which should be optional, since a user could be created 
+     * without the use of an external provider (i.e. Google or Apple), through our own email/pass authentication.
+     * 
+     */
+    // full path: /api/v1/oauth/make-user
     @PostMapping("make-user")
-    public ResponseEntity<UserDTO> makeUser(@RequestParam("user") UserDTO userDTO, @RequestParam("id") String id, @RequestParam("pfp") byte[] file) {
+    public ResponseEntity<UserDTO> makeUser(@RequestParam("user") UserDTO userDTO, @RequestParam("externalUserId") String externalUserId, @RequestParam("pfp") byte[] profilePicture) {
         try {
-           UserDTO user = oauthService.makeUser(userDTO, id, file);
+           UserDTO user = oauthService.makeUser(userDTO, externalUserId, profilePicture);
            return ResponseEntity.ok().body(user);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(null);

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
@@ -8,6 +8,6 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public interface IOAuthService {
 
     AbstractUserDTO verifyUser(OAuth2User user);
-    UserDTO makeUser(UserDTO user, String externId, byte[] profilePicture);
-    FullUserDTO getUserIfExistsbyExternalId(String externId);
+    UserDTO makeUser(UserDTO user, String externalUserId, byte[] profilePicture);
+    FullUserDTO getUserIfExistsbyExternalId(String externalUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/S3/IS3Service.java
+++ b/src/main/java/com/danielagapov/spawn/Services/S3/IS3Service.java
@@ -7,8 +7,8 @@ import java.util.UUID;
 
 public interface IS3Service {
     String putObjectWithKey(byte[] file, String key);
-    void deleteObjectByUserId(UUID id);
+    void deleteObjectByUserId(UUID userId);
     String putObject(byte[] file);
     UserDTO putProfilePictureWithUser(byte[] file, UserDTO user);
-    UserDTO updateProfilePicture(byte[] file, UUID id);
+    UserDTO updateProfilePicture(byte[] file, UUID userId);
 }


### PR DESCRIPTION
- Documentation
- Changed var names from `id` & `sub` -> `userId` or `externalUserId`
- Code change:

Before:
```
// full path: /api/v1/oauth/sign-in?sub=su
    @GetMapping("sign-in?sub=sub")
```
After:
```
// full path: /api/v1/oauth/sign-in?externalUserId=externalUserId
    @GetMapping("sign-in")
```

Pretty sure the old path was causing this 404 (should probably return 500 error, not 404):
<img width="384" alt="image" src="https://github.com/user-attachments/assets/1bc5c316-4a95-4e4e-891e-aad4258cfa97" />
<img width="380" alt="image" src="https://github.com/user-attachments/assets/64457752-1d76-4558-af31-a50314bb8209" />

, given that this is the code behind it:
```
        } catch (Exception e) {
            return ResponseEntity.internalServerError().body(null);
        }
```