### PR TITLE
`full` args for more methods and controllers

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
@@ -22,11 +22,15 @@ public class ChatMessageController {
         this.chatMessageService = chatMessageService;
     }
 
-    // full path: /api/v1/chatMessages
+    // full path: /api/v1/chatMessages?full=full
     @GetMapping
-    public ResponseEntity<List<ChatMessageDTO>> getChatMessages() {
+    public ResponseEntity<List<? extends IChatMessageDTO>> getChatMessages(@RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(chatMessageService.getAllChatMessages(), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(chatMessageService.convertChatMessagesToFullFeedEventChatMessages(chatMessageService.getAllChatMessages()), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(chatMessageService.getAllChatMessages(), HttpStatus.OK);
+            }
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -1,7 +1,6 @@
 package com.danielagapov.spawn.Controllers;
 
 import com.danielagapov.spawn.DTOs.FriendTagDTO;
-import com.danielagapov.spawn.DTOs.FullFriendTagDTO;
 import com.danielagapov.spawn.DTOs.IFriendTagDTO;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BaseSaveException;
@@ -23,11 +22,15 @@ public class FriendTagController {
         this.friendTagService = friendTagService;
     }
 
-    // full path: /api/v1/friendTags
+    // full path: /api/v1/friendTags?full=full
     @GetMapping
-    public ResponseEntity<List<FriendTagDTO>> getFriendTags() {
+    public ResponseEntity<List<? extends IFriendTagDTO>> getFriendTags(@RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(friendTagService.getAllFriendTags(), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(friendTagService.convertFriendTagsToFullFriendTags(friendTagService.getAllFriendTags()), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(friendTagService.getAllFriendTags(), HttpStatus.OK);
+            }
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -100,11 +103,15 @@ public class FriendTagController {
         }
     }
 
-    // full path: /api/v1/friendTags/owner/{ownerId}
+    // full path: /api/v1/friendTags/owner/{ownerId}?full=full
     @GetMapping("owner/{ownerId}")
-    public ResponseEntity<List<FriendTagDTO>> getFriendTagsByOwnerId(@PathVariable UUID ownerId) {
+    public ResponseEntity<List<? extends IFriendTagDTO>> getFriendTagsByOwnerId(@PathVariable UUID ownerId, @RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(friendTagService.getFriendTagsByOwnerId(ownerId), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(friendTagService.convertFriendTagsToFullFriendTags(friendTagService.getFriendTagsByOwnerId(ownerId)), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(friendTagService.getFriendTagsByOwnerId(ownerId), HttpStatus.OK);
+            }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -30,11 +30,15 @@ public class UserController {
         this.s3Service = s3Service;
     }
 
-    // full path: /api/v1/users
+    // full path: /api/v1/users?full=full
     @GetMapping
-    public ResponseEntity<List<UserDTO>> getUsers() {
+    public ResponseEntity<List<? extends IUserDTO>> getUsers(@RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(userService.getAllUsers(), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getAllUsers()), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(userService.getAllUsers(), HttpStatus.OK);
+            }
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
@@ -56,11 +60,15 @@ public class UserController {
         }
     }
 
-    // full path: /api/v1/users/{id}/friends
+    // full path: /api/v1/users/{id}/friends?full=full
     @GetMapping("{id}/friends")
-    public ResponseEntity<List<UserDTO>> getUserFriends(@PathVariable UUID id) {
+    public ResponseEntity<List<? extends IOnboardedUserDTO>> getUserFriends(@PathVariable UUID id, @RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(userService.getFriendsByUserId(id), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getFriendsByUserId(id)), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(userService.getFriendsByUserId(id), HttpStatus.OK);
+            }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
@@ -78,11 +86,15 @@ public class UserController {
         }
     }
 
-    // full path: /api/v1/users/friendtag/{tagId}
+    // full path: /api/v1/users/friendTag/{tagId}?full=full
     @GetMapping("friendTag/{tagId}")
-    public ResponseEntity<List<UserDTO>> getUsersByFriendTag(@PathVariable UUID tagId) {
+    public ResponseEntity<List<? extends IOnboardedUserDTO>> getUsersByFriendTag(@PathVariable UUID tagId, @RequestParam boolean full) {
         try {
-            return new ResponseEntity<>(userService.getUsersByTagId(tagId), HttpStatus.OK);
+            if (full) {
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getUsersByTagId(tagId)), HttpStatus.OK);
+            } else {
+                return new ResponseEntity<>(userService.getUsersByTagId(tagId), HttpStatus.OK);
+            }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -32,7 +32,7 @@ public class UserController {
 
     // full path: /api/v1/users?full=full
     @GetMapping
-    public ResponseEntity<List<? extends IUserDTO>> getUsers(@RequestParam boolean full) {
+    public ResponseEntity<List<? extends IOnboardedUserDTO>> getUsers(@RequestParam boolean full) {
         try {
             if (full) {
                 return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getAllUsers()), HttpStatus.OK);

--- a/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
@@ -273,5 +273,12 @@ public class ChatMessageService implements IChatMessageService {
         );
     }
 
+    @Override
+    public List<FullEventChatMessageDTO> convertChatMessagesToFullFeedEventChatMessages(List<ChatMessageDTO> chatMessages) {
+        return chatMessages.stream()
+                .map(this::getFullChatMessageByChatMessage)
+                .collect(Collectors.toList());
+    }
+
     
 }

--- a/src/main/java/com/danielagapov/spawn/Services/ChatMessage/IChatMessageService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/ChatMessage/IChatMessageService.java
@@ -31,4 +31,5 @@ public interface IChatMessageService {
     FullEventChatMessageDTO getFullChatMessageByChatMessage(ChatMessageDTO chatMessage);
     FullEventChatMessageDTO getFullChatMessageById(UUID id);
     List<FullEventChatMessageDTO> getFullChatMessagesByEventId(UUID eventId);
+    List<FullEventChatMessageDTO> convertChatMessagesToFullFeedEventChatMessages(List<ChatMessageDTO> chatMessages);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -97,6 +97,7 @@ public class EventService implements IEventService {
         return EventMapper.toDTO(event, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
     }
 
+    @Override
     public FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId) {
         return getFullEventByEvent(getEventById(id), requestingUserId);
     }
@@ -142,6 +143,7 @@ public class EventService implements IEventService {
         }
     }
 
+    @Override
     public EventDTO saveEvent(EventDTO event) {
         try {
             Location location = locationRepository.findById(event.locationId()).orElse(null);
@@ -170,6 +172,7 @@ public class EventService implements IEventService {
         }
     }
 
+    @Override
     public List<EventDTO> getEventsByUserId(UUID userId) {
         List<Event> events = repository.findByCreatorId(userId);
 
@@ -241,6 +244,7 @@ public class EventService implements IEventService {
         return EventMapper.toDTO(eventEntity, creatorUserId, participantUserIds, invitedUserIds, chatMessageIds);
     }
 
+    @Override
     public boolean deleteEventById(UUID id) {
         if (!repository.existsById(id)) {
             throw new BaseNotFoundException(EntityType.Event, id);
@@ -255,6 +259,7 @@ public class EventService implements IEventService {
         }
     }
 
+    @Override
     public List<UserDTO> getParticipatingUsersByEventId(UUID eventId) {
         try {
             List<EventUser> eventUsers = eventUserRepository.findByEvent_Id(eventId);
@@ -276,6 +281,7 @@ public class EventService implements IEventService {
         }
     }
 
+    @Override
     public ParticipationStatus getParticipationStatus(UUID eventId, UUID userId) {
         if (!eventUserRepository.existsById(eventId)) {
             throw new BaseNotFoundException(EntityType.Event, eventId);
@@ -300,6 +306,7 @@ public class EventService implements IEventService {
     // if false -> invites them
     // if true -> return 400 in Controller to indicate that the user has already
     // been invited, or it is a bad request.
+    @Override
     public boolean inviteUser(UUID eventId, UUID userId) {
         List<EventUser> eventUsers = eventUserRepository.findByEvent_Id(eventId);
         if (eventUsers.isEmpty()) {
@@ -335,6 +342,7 @@ public class EventService implements IEventService {
     // if true -> change status
     // if false -> return 400 in controller to indicate that the user is not
     // invited/participating
+    @Override
     public boolean toggleParticipation(UUID eventId, UUID userId) {
         List<EventUser> eventUsers = eventUserRepository.findByEvent_Id(eventId);
         if (eventUsers.isEmpty()) {
@@ -356,6 +364,7 @@ public class EventService implements IEventService {
         return false;
     }
 
+    @Override
     public List<EventDTO> getEventsInvitedTo(UUID id) {
         List<EventUser> eventUsers = eventUserRepository.findByUser_Id(id);
 
@@ -375,6 +384,7 @@ public class EventService implements IEventService {
         return getEventDTOS(events);
     }
 
+    @Override
     public List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id) {
         List<EventUser> eventUsers = eventUserRepository.findByUser_Id(id);
 
@@ -399,6 +409,7 @@ public class EventService implements IEventService {
                 .toList();
     }
 
+    @Override
     public FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId) {
         return new FullFeedEventDTO(
                 event.id(),
@@ -416,6 +427,7 @@ public class EventService implements IEventService {
         );
     }
 
+    @Override
     public String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId) {
         // get event creator from eventDTO
 
@@ -428,5 +440,16 @@ public class EventService implements IEventService {
         // using that friend tag, grab its colorHexCode property to return from this method
 
         return pertainingFriendTag.colorHexCode();
+    }
+
+    @Override
+    public List<FullFeedEventDTO> convertEventsToFullFeedEvents(List<EventDTO> events, UUID requestingUserId) {
+        ArrayList<FullFeedEventDTO> fullEvents = new ArrayList<>();
+
+        for(EventDTO eventDTO : events) {
+            fullEvents.add(getFullEventByEvent(eventDTO, requestingUserId));
+        }
+
+        return fullEvents;
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -28,8 +28,9 @@ public interface IEventService {
     // Get 'Full' Event Methods:
     List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id);
     FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId);
-    public List<FullFeedEventDTO> getAllFullEvents();
+    List<FullFeedEventDTO> getAllFullEvents();
     FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId);
+    List<FullFeedEventDTO> convertEventsToFullFeedEvents(List<EventDTO> events, UUID requestingUserId);
 
     // Additional Methods:
     List<EventDTO> getEventsByFriendTagId(UUID friendTagId);

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -61,6 +61,13 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    public List<FullFriendTagDTO> getAllFullFriendTags() {
+        return getAllFriendTags().stream()
+                .map(this::getFullFriendTagByFriendTag)
+                .collect(Collectors.toList());
+    }
+
+    @Override
     public FriendTagDTO getFriendTagById(UUID id) {
         return repository.findById(id)
                 .map(friendTag -> {

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
@@ -28,4 +28,5 @@ public interface IFriendTagService {
     List<FullFriendTagDTO> getFullFriendTagsByOwnerId(UUID ownerId);
     FullFriendTagDTO getFullFriendTagById(UUID id);
     FullFriendTagDTO getFullFriendTagByFriendTag(FriendTagDTO friendTag);
+    List<FullFriendTagDTO> getAllFullFriendTags();
 }


### PR DESCRIPTION
- Added `@Request param boolean full` arg to more controller GET endpoints
- Made new helper methods in service classes, `convertXsToFullXs` to help with this, in a more clean way than having separate wrapper methods for each method to call, that are different but accomplish the same thing, like `getFullFeedEventsByUserId` -> instead of that, just keeping the old methods in tact then wrapping them with `convertEventsToFullFeedEvents()` in a more clean way