### PR TITLE
Eventcreation Endpoint & DTO Implemented

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -95,17 +95,7 @@ public class EventController {
 
     // full path: /api/v1/events
     @PostMapping
-    public ResponseEntity<IEventDTO> createEvent(@RequestBody FullFeedEventDTO newEvent) {
-        try {
-            return new ResponseEntity<>(eventService.saveEvent(newEvent), HttpStatus.CREATED);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // full path: /api/v1/events/create-with-invites
-    @PostMapping("/create-with-invites")
-    public ResponseEntity<IEventDTO> createEventWithInvites(@RequestBody EventCreationDTO eventCreationDTO) {
+    public ResponseEntity<IEventDTO> createEvent(@RequestBody EventCreationDTO eventCreationDTO) {
         try {
             IEventDTO createdEvent = eventService.createEvent(eventCreationDTO);
             return new ResponseEntity<>(createdEvent, HttpStatus.CREATED);

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -1,9 +1,6 @@
 package com.danielagapov.spawn.Controllers;
 
-import com.danielagapov.spawn.DTOs.EventDTO;
-import com.danielagapov.spawn.DTOs.FullFeedEventDTO;
-import com.danielagapov.spawn.DTOs.IEventDTO;
-import com.danielagapov.spawn.DTOs.IOnboardedUserDTO;
+import com.danielagapov.spawn.DTOs.*;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
@@ -101,6 +98,17 @@ public class EventController {
     public ResponseEntity<IEventDTO> createEvent(@RequestBody FullFeedEventDTO newEvent) {
         try {
             return new ResponseEntity<>(eventService.saveEvent(newEvent), HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // full path: /api/v1/events/create-with-invites
+    @PostMapping("/create-with-invites")
+    public ResponseEntity<IEventDTO> createEventWithInvites(@RequestBody EventCreationDTO eventCreationDTO) {
+        try {
+            IEventDTO createdEvent = eventService.createEvent(eventCreationDTO);
+            return new ResponseEntity<>(createdEvent, HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
@@ -1,0 +1,18 @@
+package com.danielagapov.spawn.DTOs;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public record EventCreationDTO(
+        UUID id,
+        String title,
+        OffsetDateTime startTime,
+        OffsetDateTime endTime,
+        UUID locationId,
+        String note,
+        UUID creator,
+        List<UUID> invitedFriendTagIds,
+        List<UUID> invitedFriendUserIds
+) implements Serializable {}

--- a/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
@@ -10,9 +10,10 @@ public record EventCreationDTO(
         String title,
         OffsetDateTime startTime,
         OffsetDateTime endTime,
-        UUID locationId,
+        LocationDTO location,
         String note,
-        UUID creator,
+        UUID creatorUserID,
         List<UUID> invitedFriendTagIds,
         List<UUID> invitedFriendUserIds
 ) implements Serializable {}
+

--- a/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/EventCreationDTO.java
@@ -12,7 +12,7 @@ public record EventCreationDTO(
         OffsetDateTime endTime,
         LocationDTO location,
         String note,
-        UUID creatorUserID,
+        UUID creatorUserId,
         List<UUID> invitedFriendTagIds,
         List<UUID> invitedFriendUserIds
 ) implements Serializable {}

--- a/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
@@ -1,5 +1,6 @@
 package com.danielagapov.spawn.Mappers;
 
+import com.danielagapov.spawn.DTOs.EventCreationDTO;
 import com.danielagapov.spawn.DTOs.EventDTO;
 import com.danielagapov.spawn.DTOs.FullFeedEventDTO;
 import com.danielagapov.spawn.Models.Event;
@@ -97,6 +98,17 @@ public class EventMapper {
         User creator = UserMapper.convertFullUserToUserEntity(dto.getCreatorUser());
         event.setCreator(creator); // Set the creator
 
+        return event;
+    }
+
+    public static Event fromCreationDTO(EventCreationDTO dto, Location location, User creator) {
+        Event event = new Event();
+        event.setTitle(dto.title());
+        event.setStartTime(dto.startTime());
+        event.setEndTime(dto.endTime());
+        event.setLocation(location);
+        event.setNote(dto.note());
+        event.setCreator(creator);
         return event;
     }
 

--- a/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
@@ -101,12 +101,12 @@ public class EventMapper {
         return event;
     }
 
-    public static Event fromCreationDTO(EventCreationDTO dto, Location location, User creator) {
+    public static Event fromCreationDTO(EventCreationDTO dto, User creator) {
         Event event = new Event();
         event.setTitle(dto.title());
         event.setStartTime(dto.startTime());
         event.setEndTime(dto.endTime());
-        event.setLocation(location);
+        event.setLocation(LocationMapper.toEntity(dto.location()));
         event.setNote(dto.note());
         event.setCreator(creator);
         return event;

--- a/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/EventMapper.java
@@ -101,15 +101,14 @@ public class EventMapper {
         return event;
     }
 
-    public static Event fromCreationDTO(EventCreationDTO dto, User creator) {
+    public static Event fromCreationDTO(EventCreationDTO dto, Location location, User creator) {
         Event event = new Event();
         event.setTitle(dto.title());
         event.setStartTime(dto.startTime());
         event.setEndTime(dto.endTime());
-        event.setLocation(LocationMapper.toEntity(dto.location()));
+        event.setLocation(location); // Use the saved/persisted location.
         event.setNote(dto.note());
         event.setCreator(creator);
         return event;
     }
-
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -186,9 +186,7 @@ public class EventService implements IEventService {
             User creator = userRepository.findById(eventCreationDTO.creatorUserId())
                     .orElseThrow(() -> new BaseNotFoundException(EntityType.User, eventCreationDTO.creatorUserId()));
 
-            Event event = EventMapper.fromCreationDTO(eventCreationDTO, creator);
-            event.setLocation(location);
-
+            Event event = EventMapper.fromCreationDTO(eventCreationDTO, location, creator);
             event = repository.save(event);
 
             Set<UUID> allInvitedUserIds = new HashSet<>();
@@ -214,8 +212,7 @@ public class EventService implements IEventService {
                 eventUserRepository.save(eventUser);
             }
 
-            return EventMapper.toDTO(event, creator.getId(), null, new ArrayList<>(allInvitedUserIds)
-                    , null);
+            return EventMapper.toDTO(event, creator.getId(), null, new ArrayList<>(allInvitedUserIds), null);
         } catch (Exception e) {
             logger.log("Error creating event: " + e.getMessage());
             throw new ApplicationException("Failed to create event", e);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -185,7 +185,6 @@ public class EventService implements IEventService {
 
             User creator = userRepository.findById(eventCreationDTO.creatorUserId())
                     .orElseThrow(() -> new BaseNotFoundException(EntityType.User, eventCreationDTO.creatorUserId()));
-]
             Event event = EventMapper.fromCreationDTO(eventCreationDTO, location, creator);
 
             event = repository.save(event);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -183,8 +183,8 @@ public class EventService implements IEventService {
         try {
             Location location = locationService.save(LocationMapper.toEntity(eventCreationDTO.location()));
 
-            User creator = userRepository.findById(eventCreationDTO.creatorUserID())
-                    .orElseThrow(() -> new BaseNotFoundException(EntityType.User, eventCreationDTO.creatorUserID()));
+            User creator = userRepository.findById(eventCreationDTO.creatorUserId())
+                    .orElseThrow(() -> new BaseNotFoundException(EntityType.User, eventCreationDTO.creatorUserId()));
 
             Event event = EventMapper.fromCreationDTO(eventCreationDTO, creator);
             event.setLocation(location);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -1,9 +1,6 @@
 package com.danielagapov.spawn.Services.Event;
 
-import com.danielagapov.spawn.DTOs.EventDTO;
-import com.danielagapov.spawn.DTOs.FullFeedEventDTO;
-import com.danielagapov.spawn.DTOs.IEventDTO;
-import com.danielagapov.spawn.DTOs.UserDTO;
+import com.danielagapov.spawn.DTOs.*;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
 
 import java.util.List;
@@ -15,6 +12,7 @@ public interface IEventService {
     // CRUD operations:
     EventDTO getEventById(UUID id);
     IEventDTO saveEvent(IEventDTO event);
+    IEventDTO createEvent(EventCreationDTO eventCreationDTO);
     EventDTO replaceEvent(EventDTO event, UUID eventId);
     boolean deleteEventById(UUID id);
 

--- a/src/main/java/com/danielagapov/spawn/Services/Location/ILocationService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Location/ILocationService.java
@@ -10,4 +10,5 @@ public interface ILocationService {
     List<LocationDTO> getAllLocations();
     LocationDTO getLocationById(UUID id);
     Location getLocationEntityById(UUID id);
+    Location save(Location location);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Location/LocationService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Location/LocationService.java
@@ -2,6 +2,7 @@ package com.danielagapov.spawn.Services.Location;
 
 import com.danielagapov.spawn.DTOs.LocationDTO;
 import com.danielagapov.spawn.Enums.EntityType;
+import com.danielagapov.spawn.Exceptions.ApplicationException;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
 import com.danielagapov.spawn.Helpers.Logger.ILogger;
@@ -49,4 +50,13 @@ public class LocationService implements ILocationService {
         return repository.findById(id).orElseThrow(() -> new BaseNotFoundException(EntityType.Location, id));
     }
 
+    @Override
+    public Location save(Location location) {
+        try {
+            return repository.save(location);
+        } catch (DataAccessException e) {
+            logger.log(e.getMessage());
+            throw new ApplicationException("Failed to save location", e);
+        }
+    }
 }

--- a/src/test/java/com/danielagapov/spawn/UserServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/UserServiceTests.java
@@ -140,4 +140,6 @@ public class UserServiceTests {
         assertFalse(result);
         verify(userRepository, times(1)).deleteById(userId);
     }
+
+
 }


### PR DESCRIPTION
Created new post endpoint to accommodate event creation that contains just friend tag ids and a list of invited users. With the friend tag ids & user ids, our back-end should be able to fetch which users the creating user intends to invite.

AI tests are passing, but let me know if anything looks fishy.

Resolves #96 