### PR TITLE
Beta Access Sign Up Domain

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/BetaAccessSignUpController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/BetaAccessSignUpController.java
@@ -1,0 +1,70 @@
+package com.danielagapov.spawn.Controllers;
+
+import com.danielagapov.spawn.DTOs.BetaAccessSignUpDTO;
+import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import com.danielagapov.spawn.Services.BetaAccessSignUp.IBetaAccessSignUpService;
+
+import java.util.List;
+
+@RestController()
+@RequestMapping("api/v1/betaAccessSignUp")
+public class BetaAccessSignUpController {
+    private final IBetaAccessSignUpService service;
+
+    public BetaAccessSignUpController(IBetaAccessSignUpService service) {
+        this.service = service;
+    }
+
+    // full path: /api/v1/betaAccessSignUp/emails
+
+    /**
+     * Use case: when we'll want to send out emails for the beta access
+     */
+    @GetMapping("emails")
+    public ResponseEntity<List<String>> getAllEmails() {
+        try {
+            return new ResponseEntity<>(service.getAllEmails(), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // full path: /api/v1/betaAccessSignUp/
+
+    /**
+     * @return returns all signed-up users, for our own internal reference,
+     * without having to check the database
+     */
+    @GetMapping
+    public ResponseEntity<List<BetaAccessSignUpDTO>> getAllRecords() {
+        try {
+            return new ResponseEntity<>(service.getAllBetaAccessSignUpRecords(), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // full path: /api/v1/betaAccessSignUp
+
+    /**
+     * Sign-up endpoint for creating a new record
+     * @param dto constructed via front-end form submission
+     * @return back the DTO after being persisted into our database if successful.
+     * Otherwise, we'll throw a 500 (INTERNAL_SERVER_ERROR).
+     */
+    @PostMapping
+    public ResponseEntity<BetaAccessSignUpDTO> signUp(@RequestBody BetaAccessSignUpDTO dto) {
+        try {
+            return new ResponseEntity<>(service.signUp(dto), HttpStatus.CREATED);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -1,5 +1,6 @@
 package com.danielagapov.spawn.Controllers;
 
+import com.danielagapov.spawn.DTOs.FriendRequestDTO;
 import com.danielagapov.spawn.DTOs.FullFriendRequestDTO;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Services.FriendRequestService.IFriendRequestService;
@@ -27,6 +28,16 @@ public class FriendRequestController {
             return new ResponseEntity<>(friendRequestService.getIncomingFriendRequestsByUserId(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    // full path: /api/v1/users/friend-request
+    @PostMapping("friend-request")
+    public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendReq) {
+        try {
+            return new ResponseEntity<>(friendRequestService.saveFriendRequest(friendReq), HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -1,6 +1,5 @@
 package com.danielagapov.spawn.Controllers;
 
-import com.danielagapov.spawn.DTOs.FriendRequestDTO;
 import com.danielagapov.spawn.DTOs.IOnboardedUserDTO;
 import com.danielagapov.spawn.DTOs.RecommendedFriendUserDTO;
 import com.danielagapov.spawn.DTOs.UserDTO;
@@ -133,16 +132,6 @@ public class UserController {
             }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // full path: /api/v1/users/friend-request
-    @PostMapping("friend-request")
-    public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendReq) {
-        try {
-            return new ResponseEntity<>(friendRequestService.saveFriendRequest(friendReq), HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/DTOs/BetaAccessSignUpDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/BetaAccessSignUpDTO.java
@@ -1,0 +1,24 @@
+package com.danielagapov.spawn.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class BetaAccessSignUpDTO implements Serializable {
+    private UUID id;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private OffsetDateTime signedUpAt;
+    private String additionalComments;
+    private String instagramUsername;
+}

--- a/src/main/java/com/danielagapov/spawn/Mappers/BetaAccessSignUpMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/BetaAccessSignUpMapper.java
@@ -1,0 +1,40 @@
+package com.danielagapov.spawn.Mappers;
+
+import com.danielagapov.spawn.DTOs.BetaAccessSignUpDTO;
+import com.danielagapov.spawn.Models.BetaAccessSignUp;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BetaAccessSignUpMapper {
+
+    public static BetaAccessSignUpDTO toDTO(BetaAccessSignUp entity) {
+        return new BetaAccessSignUpDTO(
+                entity.getId(),
+                entity.getEmail(),
+                entity.getFirstName(),
+                entity.getLastName(),
+                entity.getSignedUpAt(),
+                entity.getAdditionalComments(),
+                entity.getInstagramUsername()
+        );
+    }
+
+    public static BetaAccessSignUp toEntity(BetaAccessSignUpDTO dto) {
+        return new BetaAccessSignUp(
+                dto.getId(),
+                dto.getEmail(),
+                dto.getFirstName(),
+                dto.getLastName(),
+                dto.getSignedUpAt(),
+                dto.getAdditionalComments(),
+                dto.getInstagramUsername()
+        );
+    }
+
+    public static List<BetaAccessSignUpDTO> toDTOList(List<BetaAccessSignUp> entities) {
+        return entities.stream()
+                .map(BetaAccessSignUpMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Models/BetaAccessSignUp.java
+++ b/src/main/java/com/danielagapov/spawn/Models/BetaAccessSignUp.java
@@ -1,0 +1,36 @@
+package com.danielagapov.spawn.Models;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class BetaAccessSignUp implements Serializable {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+    private String email;
+    private String firstName;
+    private String lastName;
+    private OffsetDateTime signedUpAt;
+    private String additionalComments;
+    private String instagramUsername;
+
+    @PrePersist
+    public void prePersist() {
+        // this happens upon persistence to our database in `BetaAccessSignUpService::signUp()`
+        if (this.signedUpAt == null) {
+            this.signedUpAt = OffsetDateTime.now();
+        }
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Repositories/IBetaAccessSignUpRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IBetaAccessSignUpRepository.java
@@ -1,0 +1,10 @@
+package com.danielagapov.spawn.Repositories;
+
+import com.danielagapov.spawn.Models.BetaAccessSignUp;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface IBetaAccessSignUpRepository extends JpaRepository<BetaAccessSignUp, UUID>{ }

--- a/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/BetaAccessSignUpService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/BetaAccessSignUpService.java
@@ -1,0 +1,80 @@
+package com.danielagapov.spawn.Services.BetaAccessSignUp;
+
+import com.danielagapov.spawn.DTOs.BetaAccessSignUpDTO;
+import com.danielagapov.spawn.Enums.EntityType;
+import com.danielagapov.spawn.Exceptions.Base.BaseSaveException;
+import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
+import com.danielagapov.spawn.Exceptions.Logger.ILogger;
+import com.danielagapov.spawn.Mappers.BetaAccessSignUpMapper;
+import com.danielagapov.spawn.Models.BetaAccessSignUp;
+import com.danielagapov.spawn.Repositories.IBetaAccessSignUpRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class BetaAccessSignUpService implements IBetaAccessSignUpService {
+    private final IBetaAccessSignUpRepository repository;
+    private final ILogger logger;
+
+    @Autowired
+    public BetaAccessSignUpService(IBetaAccessSignUpRepository repository, ILogger logger) {
+        this.repository = repository;
+        this.logger = logger;
+    }
+
+    /**
+     * This would likely be used for internal use, just to check who's signed up
+     * @return all beta access sign up record DTOs
+     */
+    @Override
+    public List<BetaAccessSignUpDTO> getAllBetaAccessSignUpRecords() {
+        try {
+            return BetaAccessSignUpMapper.toDTOList(repository.findAll());
+        } catch (DataAccessException e) {
+            logger.log(e.getMessage());
+            throw new BasesNotFoundException(EntityType.FriendTag);
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * @return Strings of all emails of beta access sign up records
+     */
+    @Override
+    public List<String> getAllEmails() {
+        try {
+            return getAllBetaAccessSignUpRecords().stream()
+                    .map(BetaAccessSignUpDTO::getEmail)
+                    .collect(Collectors.toList());
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * This is meant for saving a record to the database upon signing up through our site
+     * @param dto constructed in the front-end of our site via a form input
+     * @return back the dto after persisting to database, if successful. Throws otherwise.
+     */
+    @Override
+    public BetaAccessSignUpDTO signUp(BetaAccessSignUpDTO dto) {
+        try {
+            BetaAccessSignUp entity = BetaAccessSignUpMapper.toEntity(dto);
+            entity = repository.save(entity);
+            return BetaAccessSignUpMapper.toDTO(entity);
+        } catch (DataAccessException e) {
+            logger.log(e.getMessage());
+            throw new BaseSaveException("Failed to save beta access sign up record: " + e.getMessage());
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/IBetaAccessSignUpService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/IBetaAccessSignUpService.java
@@ -1,0 +1,23 @@
+package com.danielagapov.spawn.Services.BetaAccessSignUp;
+
+import com.danielagapov.spawn.DTOs.BetaAccessSignUpDTO;
+
+import java.util.List;
+
+public interface IBetaAccessSignUpService {
+    /**
+     * This is meant for saving a record to the database upon signing up through our site
+     * @param dto constructed in the front-end of our site via a form input
+     * @return back the dto after persisting to database, if successful. Throws otherwise.
+     */
+    BetaAccessSignUpDTO signUp(BetaAccessSignUpDTO dto);
+    /**
+     * This would likely be used for internal use, just to check who's signed up
+     * @return all beta access sign up record DTOs
+     */
+    List<BetaAccessSignUpDTO> getAllBetaAccessSignUpRecords();
+    /**
+     * @return Strings of all emails of beta access sign up records
+     */
+    List<String> getAllEmails();
+}


### PR DESCRIPTION
This domain will be used by our site for gathering beta access users, which we'll then invite. Therefore, I've made 3 endpoints to satisfy requirements that would come with these tasks. 

## Endpoints (will be available once this PR is reviewed & merged):
- (POST) Sign Up: upon submitting front-end form
    -  [spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp](spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp)
- (GET) All Emails: for the purpose of when we're sending our beta access invites
    - [spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp/emails](spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp/emails)
- (GET) All Records: for internal use to see all info from records 
    - [spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp](spawn-app-back-end-production.up.railway.app/api/v1/betaAccessSignUp)
    - (as opposed to querying the database directly (which only Evan, Shane, and I have access to)

## Entity (subject-to-change):
`BetaAccessSignUp`, with properties:
```
    UUID id;
    String email;
    String firstName;
    String lastName;
    OffsetDateTime signedUpAt;
    String additionalComments;
    String instagramUsername;
```

Service classes and endpoints are documented. 