### PR TITLE
Recommend friend bugfix

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Repositories/IFriendRequestsRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IFriendRequestsRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 @Repository
 public interface IFriendRequestsRepository extends JpaRepository<FriendRequest, UUID> {
     List<FriendRequest> findByReceiverId(UUID receiverId);
+
+    List<FriendRequest> findBySenderId(UUID userId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/FriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/FriendRequestService.java
@@ -105,4 +105,21 @@ public class FriendRequestService implements IFriendRequestService {
         }
         return fullFriendRequests;
     }
+
+    @Override
+    public List<FriendRequestDTO> getSentFriendRequestsByUserId(UUID userId) {
+        try {
+            // Retrieve friend requests sent by the user
+            List<FriendRequest> sentRequests = repository.findBySenderId(userId);
+
+            // Convert the FriendRequest entities to DTOs before returning
+            return FriendRequestMapper.toDTOList(sentRequests);
+        } catch (DataAccessException e) {
+            logger.log("Database access error while retrieving sent friend requests for userId: " + userId);
+            throw new BaseNotFoundException(EntityType.FriendRequest, userId);
+        } catch (Exception e) {
+            logger.log("Unexpected error while retrieving sent friend requests for userId: " + userId + ", Error: " + e.getMessage());
+            throw e;
+        }
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/IFriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/IFriendRequestService.java
@@ -3,6 +3,7 @@ package com.danielagapov.spawn.Services.FriendRequestService;
 import com.danielagapov.spawn.DTOs.FriendRequestDTO;
 import com.danielagapov.spawn.DTOs.FullFriendRequestDTO;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/IFriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/IFriendRequestService.java
@@ -14,4 +14,6 @@ public interface IFriendRequestService {
     void deleteFriendRequest(UUID id);
 
     List<FullFriendRequestDTO> convertFriendRequestsToFullFriendRequests (List<FriendRequestDTO> friendRequests);
+
+    List<FriendRequestDTO> getSentFriendRequestsByUserId(UUID userId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -625,20 +625,4 @@ public class UserService implements IUserService {
             throw e;
         }
     }
-
-    public boolean areUsersFriends(UUID userId1, UUID userId2) {
-        try {
-            List<UserDTO> friendsOfUser1 = getFriendsByUserId(userId1);
-
-            if (friendsOfUser1 == null || friendsOfUser1.isEmpty()) {
-                return false;
-            }
-
-            return friendsOfUser1.stream()
-                    .anyMatch(friend -> friend.id().equals(userId2));
-        } catch (Exception e) {
-            logger.log(String.format("Error checking friendship between %s and %s: %s", userId1, userId2, e.getMessage()));
-            throw new ApplicationException("Error checking friendship status", e);
-        }
-    }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -410,8 +410,8 @@ public class UserService implements IUserService {
 
             // Create a set of the requesting user's friends, users they've sent requests to, users they've received requests from, and self for quick lookup
             Set<UUID> excludedUserIds = new HashSet<>(requestingUserFriendIds);
-            excludedUserIds.addAll(sentFriendRequestIds);
-            excludedUserIds.addAll(receivedFriendRequestIds);
+            excludedUserIds.addAll(sentFriendRequestReceiverUserIds);
+            excludedUserIds.addAll(receivedFriendRequestSenderUserIds);
             excludedUserIds.add(userId); // Exclude self
 
             // Collect friends of friends (excluding already existing friends, sent/received requests, and self)

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -408,7 +408,7 @@ public class UserService implements IUserService {
                     .map(request -> request.getSenderUser().id())
                     .collect(Collectors.toList());
 
-            // Create a set of the requesting user's friends, sent requests, received requests, and self for quick lookup
+            // Create a set of the requesting user's friends, users they've sent requests to, users they've received requests from, and self for quick lookup
             Set<UUID> excludedUserIds = new HashSet<>(requestingUserFriendIds);
             excludedUserIds.addAll(sentFriendRequestIds);
             excludedUserIds.addAll(receivedFriendRequestIds);

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -397,7 +397,7 @@ public class UserService implements IUserService {
             List<UUID> requestingUserFriendIds = getFriendUserIdsByUserId(userId);
 
             // Fetch users who have already received a friend request from the user
-            List<UUID> sentFriendRequestIds = friendRequestService.getSentFriendRequestsByUserId(userId)
+            List<UUID> sentFriendRequestReceiverUserIds = friendRequestService.getSentFriendRequestsByUserId(userId)
                     .stream()
                     .map(FriendRequestDTO::receiverUserId)
                     .collect(Collectors.toList());

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -403,7 +403,7 @@ public class UserService implements IUserService {
                     .collect(Collectors.toList());
 
             // Fetch users who have sent a friend request to the user (pending requests)
-            List<UUID> receivedFriendRequestIds = friendRequestService.getIncomingFriendRequestsByUserId(userId)
+            List<UUID> receivedFriendRequestSenderUserIds = friendRequestService.getIncomingFriendRequestsByUserId(userId)
                     .stream()
                     .map(request -> request.getSenderUser().id())
                     .collect(Collectors.toList());


### PR DESCRIPTION
Adjusted getRecommendedFriendsForUserId in UserService to now:

- Only recommend friends that you have not already sent a request to
- Only recommend friends that you do not have a request from
- Exclude the current user from the list of recommendations

Resolves #151 