### PR TITLE
Reworked friend req endpoints

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -2,6 +2,7 @@ package com.danielagapov.spawn.Controllers;
 
 import com.danielagapov.spawn.DTOs.FriendRequestDTO;
 import com.danielagapov.spawn.DTOs.FullFriendRequestDTO;
+import com.danielagapov.spawn.Enums.FriendRequestAction;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Services.FriendRequestService.IFriendRequestService;
 import org.springframework.http.HttpStatus;
@@ -43,24 +44,19 @@ public class FriendRequestController {
         }
     }
 
-    // full path: /api/v1/friend-requests/{friendRequestId}/accept
-    @PutMapping("{friendRequestId}/accept")
-    public ResponseEntity<Void> acceptFriendRequest(@PathVariable UUID friendRequestId) {
+    // full path: /api/v1/friend-requests/{friendRequestId}?friendRequestAction={accept/reject}
+    @PutMapping("{friendRequestId}")
+    public ResponseEntity<Void> acceptFriendRequest(@PathVariable UUID friendRequestId, @RequestParam FriendRequestAction friendRequestAction) {
         try {
-            friendRequestService.acceptFriendRequest(friendRequestId);
-            return new ResponseEntity<>(HttpStatus.OK);
-        } catch (BaseNotFoundException e) {
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
+            if (friendRequestAction == FriendRequestAction.accept){
+                friendRequestService.acceptFriendRequest(friendRequestId);
+            } else if (friendRequestAction == FriendRequestAction.reject) {
+                friendRequestService.deleteFriendRequest(friendRequestId);
+            } else {
+                // deal with null/invalid argument for `friendRequestAction`
+                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            }
 
-    // full path: /api/v1/friend-requests/{friendRequestId}/reject
-    @PutMapping("{friendRequestId}/reject")
-    public ResponseEntity<Void> rejectFriendRequest(@PathVariable UUID friendRequestId) {
-        try {
-            friendRequestService.deleteFriendRequest(friendRequestId);
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -22,7 +22,7 @@ public class FriendRequestController {
     }
 
     // full path: /api/v1/friend-requests/incoming/{userId}
-    @GetMapping("{userId}")
+    @GetMapping("incoming/{userId}")
     public ResponseEntity<List<FullFriendRequestDTO>> getIncomingFriendRequestsByUserId(@PathVariable UUID userId) {
         try {
             return new ResponseEntity<>(friendRequestService.getIncomingFriendRequestsByUserId(userId), HttpStatus.OK);

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.UUID;
 
 @RestController
-@RequestMapping("api/v1/users")
+@RequestMapping("api/v1/friend-requests")
 public class FriendRequestController {
 
     private final IFriendRequestService friendRequestService;
@@ -21,11 +21,11 @@ public class FriendRequestController {
         this.friendRequestService = friendRequestService;
     }
 
-    // full path: /api/v1/users/{id}/friend-requests
-    @GetMapping("{id}/friend-requests")
-    public ResponseEntity<List<FullFriendRequestDTO>> getIncomingFriendRequests(@PathVariable UUID id) {
+    // full path: /api/v1/friend-requests/incoming/{userId}
+    @GetMapping("{userId}")
+    public ResponseEntity<List<FullFriendRequestDTO>> getIncomingFriendRequestsByUserId(@PathVariable UUID userId) {
         try {
-            return new ResponseEntity<>(friendRequestService.getIncomingFriendRequestsByUserId(id), HttpStatus.OK);
+            return new ResponseEntity<>(friendRequestService.getIncomingFriendRequestsByUserId(userId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (Exception e) {
@@ -33,19 +33,19 @@ public class FriendRequestController {
         }
     }
 
-    // full path: /api/v1/users/friend-request
-    @PostMapping("friend-request")
-    public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendReq) {
+    // full path: /api/v1/friend-request
+    @PostMapping
+    public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendRequest) {
         try {
-            return new ResponseEntity<>(friendRequestService.saveFriendRequest(friendReq), HttpStatus.CREATED);
+            return new ResponseEntity<>(friendRequestService.saveFriendRequest(friendRequest), HttpStatus.CREATED);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
 
-    // full path: /api/v1/users/{userId}/friend-requests/{friendRequestId}/accept
-    @PutMapping("{userId}/friend-requests/{friendRequestId}/accept")
-    public ResponseEntity<Void> acceptFriendRequest(@PathVariable UUID userId, @PathVariable UUID friendRequestId) {
+    // full path: /api/v1/friend-requests/{friendRequestId}/accept
+    @PutMapping("{friendRequestId}/accept")
+    public ResponseEntity<Void> acceptFriendRequest(@PathVariable UUID friendRequestId) {
         try {
             friendRequestService.acceptFriendRequest(friendRequestId);
             return new ResponseEntity<>(HttpStatus.OK);
@@ -56,9 +56,9 @@ public class FriendRequestController {
         }
     }
 
-    // full path: /api/v1/users/{userId}/friend-requests/{friendRequestId}/reject
-    @PutMapping("{userId}/friend-requests/{friendRequestId}/reject")
-    public ResponseEntity<Void> rejectFriendRequest(@PathVariable UUID userId, @PathVariable UUID friendRequestId) {
+    // full path: /api/v1/friend-requests/{friendRequestId}/reject
+    @PutMapping("{friendRequestId}/reject")
+    public ResponseEntity<Void> rejectFriendRequest(@PathVariable UUID friendRequestId) {
         try {
             friendRequestService.deleteFriendRequest(friendRequestId);
             return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -33,7 +33,7 @@ public class FriendRequestController {
         }
     }
 
-    // full path: /api/v1/friend-request
+    // full path: /api/v1/friend-requests
     @PostMapping
     public ResponseEntity<FriendRequestDTO> createFriendRequest(@RequestBody FriendRequestDTO friendRequest) {
         try {

--- a/src/main/java/com/danielagapov/spawn/Enums/FriendRequestAction.java
+++ b/src/main/java/com/danielagapov/spawn/Enums/FriendRequestAction.java
@@ -1,0 +1,5 @@
+package com.danielagapov.spawn.Enums;
+
+public enum FriendRequestAction {
+    accept, reject
+}

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/FriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequestService/FriendRequestService.java
@@ -80,9 +80,14 @@ public class FriendRequestService implements IFriendRequestService {
 
     @Override
     public void acceptFriendRequest(UUID id) {
-        FriendRequest fr = repository.findById(id).orElseThrow(() -> new BaseNotFoundException(EntityType.FriendRequest, id));
-        userService.saveFriendToUser(fr.getSender().getId(), fr.getReceiver().getId());
-        deleteFriendRequest(id);
+        try {
+            FriendRequest fr = repository.findById(id).orElseThrow(() -> new BaseNotFoundException(EntityType.FriendRequest, id));
+            userService.saveFriendToUser(fr.getSender().getId(), fr.getReceiver().getId());
+            deleteFriendRequest(id);
+        } catch (Exception e) {
+            logger.log(e.getMessage());
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
- more consise endpoints
    - consolidated accept & reject endpoints into one with a new `@RequestParam` of new enum type `FriendRequestAction`
    - removed unused `userId` path variable arguments from them
    - removed prefix `/users/` in URL
- try-catching in `acceptFriendRequest()` (cherry-picked this commit into `main` already)

To note, this does not address the bug in #154 