### PR TITLE
Fix circular dependency between `getFullUserByUser()` and `convertUsersToFullUsers()` + `getRecommendedFriends` excluding existing friends

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -132,7 +133,7 @@ public class EventController {
     public ResponseEntity<List<? extends IOnboardedUserDTO>> getUsersParticipatingInEvent(@PathVariable UUID id, @RequestParam(value="full", required=false) boolean full) {
         try {
             if (full) {
-                return new ResponseEntity<>(userService.convertUsersToFullUsers(eventService.getParticipatingUsersByEventId(id)), HttpStatus.OK);
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(eventService.getParticipatingUsersByEventId(id), new HashSet<>()), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(eventService.getParticipatingUsersByEventId(id), HttpStatus.OK);
             }

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.UUID;
 
@@ -34,7 +35,7 @@ public class UserController {
     public ResponseEntity<List<? extends IOnboardedUserDTO>> getUsers(@RequestParam(value="full", required=false) boolean full) {
         try {
             if (full) {
-                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getAllUsers()), HttpStatus.OK);
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getAllUsers(), new HashSet<>()), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(userService.getAllUsers(), HttpStatus.OK);
             }
@@ -86,7 +87,7 @@ public class UserController {
     public ResponseEntity<List<? extends IOnboardedUserDTO>> getUsersByFriendTag(@PathVariable UUID tagId, @RequestParam(value="full", required=false) boolean full) {
         try {
             if (full) {
-                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getUsersByTagId(tagId)), HttpStatus.OK);
+                return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getUsersByTagId(tagId), new HashSet<>()), HttpStatus.OK);
             } else {
                 return new ResponseEntity<>(userService.getUsersByTagId(tagId), HttpStatus.OK);
             }

--- a/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
@@ -28,10 +28,7 @@ import com.danielagapov.spawn.Services.User.IUserService;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -269,7 +266,7 @@ public class ChatMessageService implements IChatMessageService {
                 chatMessage.timestamp(),
                 userService.getFullUserById(chatMessage.senderUserId()),
                 chatMessage.eventId(),
-                userService.convertUsersToFullUsers(getChatMessageLikes(chatMessage.id()))
+                userService.convertUsersToFullUsers(getChatMessageLikes(chatMessage.id()), new HashSet<>())
         );
     }
 

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -509,8 +509,8 @@ public class EventService implements IEventService {
                 locationService.getLocationById(event.locationId()),
                 event.note(),
                 userService.getFullUserById(event.creatorUserId()),
-                userService.convertUsersToFullUsers(userService.getParticipantsByEventId(event.id())),
-                userService.convertUsersToFullUsers(userService.getInvitedByEventId(event.id())),
+                userService.convertUsersToFullUsers(userService.getParticipantsByEventId(event.id()), new HashSet<>()),
+                userService.convertUsersToFullUsers(userService.getInvitedByEventId(event.id()), new HashSet<>()),
                 chatMessageService.getFullChatMessagesByEventId(event.id()),
                 requestingUserId != null ? getFriendTagColorHexCodeForRequestingUser(event, requestingUserId) : null,
                 requestingUserId != null ? getParticipationStatus(event.id(), requestingUserId) : null

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -14,6 +14,8 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
+import java.util.HashSet;
+
 @Service
 public class OAuthService implements IOAuthService {
     private final IUserIdExternalIdMapRepository externalIdMapRepository;
@@ -63,7 +65,7 @@ public class OAuthService implements IOAuthService {
                 logger.log(String.format("External user detected, saving mapping: {externalUserId: %s, userDTO: %s}", externalUserId, userDTO));
                 saveMapping(externalUserId, userDTO, provider);
             }
-            FullUserDTO fullUserDTO = userService.getFullUserByUser(userDTO);
+            FullUserDTO fullUserDTO = userService.getFullUserByUser(userDTO, new HashSet<>());
             logger.log(String.format("Returning FullUserDTO of newly made user: {fullUserDTO: %s}", fullUserDTO));
             return fullUserDTO;
         } catch (DataAccessException e) {

--- a/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
@@ -9,6 +9,7 @@ import com.danielagapov.spawn.Models.User;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 public interface IUserService {
@@ -50,7 +51,8 @@ public interface IUserService {
     List<UUID> getInvitedUserIdsByEventId(UUID eventId);
 
     // Helper
-    FullUserDTO getFullUserByUser(UserDTO user);
-    List<FullUserDTO> convertUsersToFullUsers(List<UserDTO> users);
+    FullUserDTO getFullUserByUser(UserDTO user, Set<UUID> visitedUsers);
+
+    List<FullUserDTO> convertUsersToFullUsers(List<UserDTO> users, Set<UUID> visitedUsers);
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -644,18 +644,19 @@ public class UserService implements IUserService {
             List<UserDTO> userFriends = getFriendsByUserId(requestingUserId);
             List<FullUserDTO> fullUserFriends = convertUsersToFullUsers(userFriends, new HashSet<>());
 
-            List<FullFriendUserDTO> fullFriendUserDTOList = new ArrayList<FullFriendUserDTO>();
+            List<FullFriendUserDTO> fullFriendUserDTOList = new ArrayList<>();
             for (FullUserDTO user : fullUserFriends) {
                 FullFriendUserDTO fullFriendUserDTO = new FullFriendUserDTO(
                         user.id(),
-                        convertUsersToFullUsers(getFriendsByUserId(user.id()), new HashSet<>()),
+                        user.friends(),
                         user.username(),
                         user.profilePicture(),
                         user.firstName(),
                         user.lastName(),
                         user.bio(),
-                        friendTagService.convertFriendTagsToFullFriendTags(friendTagService.getFriendTagsByOwnerId(user.id())),
+                        user.friendTags(),
                         user.email(),
+                        // only added property from `FullUserDTO`:
                         friendTagService.getPertainingFriendTagsForFriend(requestingUserId, user.id())
                 );
                 fullFriendUserDTOList.add(fullFriendUserDTO);

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -403,18 +403,21 @@ public class UserService implements IUserService {
             List<UUID> sentFriendRequestReceiverUserIds = friendRequestService.getSentFriendRequestsByUserId(userId)
                     .stream()
                     .map(FriendRequestDTO::receiverUserId)
-                    .collect(Collectors.toList());
+                    .toList();
 
             // Map mutual friends to RecommendedFriendUserDTO
             List<UUID> receivedFriendRequestSenderUserIds = friendRequestService.getIncomingFriendRequestsByUserId(userId)
                     .stream()
                     .map(request -> request.getSenderUser().id())
-                    .collect(Collectors.toList());
+                    .toList();
+
+            List<UUID> existingFriendUserIds = getFriendUserIdsByUserId(userId);
 
             // Create a set of the requesting user's friends, users they've sent requests to, users they've received requests from, and self for quick lookup
             Set<UUID> excludedUserIds = new HashSet<>(requestingUserFriendIds);
             excludedUserIds.addAll(sentFriendRequestReceiverUserIds);
             excludedUserIds.addAll(receivedFriendRequestSenderUserIds);
+            excludedUserIds.addAll(existingFriendUserIds);
             excludedUserIds.add(userId); // Exclude self
 
             // Collect friends of friends (excluding already existing friends, sent/received requests, and self)

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
@@ -257,7 +257,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(chatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(new ArrayList<>());
         FullEventChatMessageDTO fullDto = chatMessageService.getFullChatMessageById(chatMessageId);
         assertNotNull(fullDto);
         assertEquals(chatMessageId, fullDto.id());
@@ -293,7 +293,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(chatMessage2)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(UUID.randomUUID(), List.of(), "user", "avatar.jpg", "First", "Last", "bio", List.of(), "user@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(new ArrayList<>());
         List<FullEventChatMessageDTO> result = chatMessageService.getFullChatMessagesByEventId(eventId);
         assertNotNull(result);
         assertEquals(2, result.size());
@@ -517,7 +517,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(dummyChatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(senderId)).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(new ArrayList<>());
         FullEventChatMessageDTO fullDto = chatMessageService.getFullChatMessageByChatMessage(chatMessageDTO);
         assertNotNull(fullDto);
         assertEquals(chatMessageId, fullDto.id());
@@ -553,7 +553,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(dummyChatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(senderId)).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(new ArrayList<>());
         List<FullEventChatMessageDTO> result = chatMessageService.convertChatMessagesToFullFeedEventChatMessages(chatMessageDTOs);
         assertNotNull(result);
         assertEquals(1, result.size());

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
@@ -29,10 +29,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.dao.DataAccessException;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -260,7 +257,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(chatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
         FullEventChatMessageDTO fullDto = chatMessageService.getFullChatMessageById(chatMessageId);
         assertNotNull(fullDto);
         assertEquals(chatMessageId, fullDto.id());
@@ -296,7 +293,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(chatMessage2)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(UUID.randomUUID(), List.of(), "user", "avatar.jpg", "First", "Last", "bio", List.of(), "user@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
         List<FullEventChatMessageDTO> result = chatMessageService.getFullChatMessagesByEventId(eventId);
         assertNotNull(result);
         assertEquals(2, result.size());
@@ -520,7 +517,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(dummyChatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(senderId)).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
         FullEventChatMessageDTO fullDto = chatMessageService.getFullChatMessageByChatMessage(chatMessageDTO);
         assertNotNull(fullDto);
         assertEquals(chatMessageId, fullDto.id());
@@ -556,7 +553,7 @@ public class ChatMessageServiceTests {
         when(chatMessageLikesRepository.findByChatMessage(dummyChatMessage)).thenReturn(new ArrayList<>());
         FullUserDTO fullUser = new FullUserDTO(senderId, List.of(), "username", "avatar.jpg", "First", "Last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(senderId)).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any())).thenReturn(new ArrayList<>());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(new ArrayList<>());
         List<FullEventChatMessageDTO> result = chatMessageService.convertChatMessagesToFullFeedEventChatMessages(chatMessageDTOs);
         assertNotNull(result);
         assertEquals(1, result.size());

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
@@ -397,7 +397,7 @@ public class EventServiceTests {
                 .thenReturn(new LocationDTO(UUID.randomUUID(), "Location", 0.0, 0.0));
         when(userService.getFullUserById(any(UUID.class))).thenReturn(new FullUserDTO(
                 UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
         // Stub friend tag lookup; for events without a requesting user, no friend tag is applied.
         when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(null);
@@ -436,7 +436,7 @@ public class EventServiceTests {
         FullUserDTO fullUser = new FullUserDTO(
                 UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(eventId)).thenReturn(List.of());
         // Stub friend tag lookup
         com.danielagapov.spawn.DTOs.FriendTagDTO friendTag = mock(com.danielagapov.spawn.DTOs.FriendTagDTO.class);
@@ -690,7 +690,7 @@ public class EventServiceTests {
                 .thenReturn(new LocationDTO(UUID.randomUUID(), "Location", 0.0, 0.0));
         when(userService.getFullUserById(any(UUID.class)))
                 .thenReturn(new FullUserDTO(UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
 
         com.danielagapov.spawn.DTOs.FriendTagDTO dummyTag = mock(com.danielagapov.spawn.DTOs.FriendTagDTO.class);
@@ -722,7 +722,7 @@ public class EventServiceTests {
         when(userService.getFullUserById(eventDTO.creatorUserId())).thenReturn(fullUser);
         when(userService.getParticipantsByEventId(eventDTO.id())).thenReturn(List.of());
         when(userService.getInvitedByEventId(eventDTO.id())).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(eventDTO.id())).thenReturn(List.of());
 
         FullFeedEventDTO fullEvent = eventService.getFullEventByEvent(eventDTO, null);
@@ -764,7 +764,7 @@ public class EventServiceTests {
                         "first", "last", "bio", List.of(), "email@example.com"));
         when(userService.getParticipantsByEventId(any(UUID.class))).thenReturn(List.of());
         when(userService.getInvitedByEventId(any(UUID.class))).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
         // Stub participation: existsById true and findByEvent_Id returns a dummy EventUser not matching the requesting user.
         when(eventUserRepository.existsById(any(UUID.class))).thenReturn(true);
@@ -794,7 +794,7 @@ public class EventServiceTests {
                 .thenReturn(new FullUserDTO(UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
         when(userService.getParticipantsByEventId(any(UUID.class))).thenReturn(List.of());
         when(userService.getInvitedByEventId(any(UUID.class))).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
 
         // Stub friend tag lookup to return null (self-owned accent)

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
@@ -397,7 +397,7 @@ public class EventServiceTests {
                 .thenReturn(new LocationDTO(UUID.randomUUID(), "Location", 0.0, 0.0));
         when(userService.getFullUserById(any(UUID.class))).thenReturn(new FullUserDTO(
                 UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
         // Stub friend tag lookup; for events without a requesting user, no friend tag is applied.
         when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(null);
@@ -436,7 +436,7 @@ public class EventServiceTests {
         FullUserDTO fullUser = new FullUserDTO(
                 UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com");
         when(userService.getFullUserById(any(UUID.class))).thenReturn(fullUser);
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(eventId)).thenReturn(List.of());
         // Stub friend tag lookup
         com.danielagapov.spawn.DTOs.FriendTagDTO friendTag = mock(com.danielagapov.spawn.DTOs.FriendTagDTO.class);
@@ -690,7 +690,7 @@ public class EventServiceTests {
                 .thenReturn(new LocationDTO(UUID.randomUUID(), "Location", 0.0, 0.0));
         when(userService.getFullUserById(any(UUID.class)))
                 .thenReturn(new FullUserDTO(UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
 
         com.danielagapov.spawn.DTOs.FriendTagDTO dummyTag = mock(com.danielagapov.spawn.DTOs.FriendTagDTO.class);
@@ -722,7 +722,7 @@ public class EventServiceTests {
         when(userService.getFullUserById(eventDTO.creatorUserId())).thenReturn(fullUser);
         when(userService.getParticipantsByEventId(eventDTO.id())).thenReturn(List.of());
         when(userService.getInvitedByEventId(eventDTO.id())).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(eventDTO.id())).thenReturn(List.of());
 
         FullFeedEventDTO fullEvent = eventService.getFullEventByEvent(eventDTO, null);
@@ -764,7 +764,7 @@ public class EventServiceTests {
                         "first", "last", "bio", List.of(), "email@example.com"));
         when(userService.getParticipantsByEventId(any(UUID.class))).thenReturn(List.of());
         when(userService.getInvitedByEventId(any(UUID.class))).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
         // Stub participation: existsById true and findByEvent_Id returns a dummy EventUser not matching the requesting user.
         when(eventUserRepository.existsById(any(UUID.class))).thenReturn(true);
@@ -794,7 +794,7 @@ public class EventServiceTests {
                 .thenReturn(new FullUserDTO(UUID.randomUUID(), List.of(), "fullUsername", "avatar.jpg", "first", "last", "bio", List.of(), "email@example.com"));
         when(userService.getParticipantsByEventId(any(UUID.class))).thenReturn(List.of());
         when(userService.getInvitedByEventId(any(UUID.class))).thenReturn(List.of());
-        when(userService.convertUsersToFullUsers(any())).thenReturn(List.of());
+        when(userService.convertUsersToFullUsers(any(), new HashSet<>())).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
 
         // Stub friend tag lookup to return null (self-owned accent)

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/OAuthServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/OAuthServiceTests.java
@@ -18,6 +18,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.dao.DataAccessException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -80,7 +81,7 @@ public class OAuthServiceTests {
         when(externalIdMapRepository.existsById("externalId123")).thenReturn(false);
         when(userService.existsByEmail(userDTO.email())).thenReturn(false);
         when(userService.saveUserWithProfilePicture(userDTO, profilePicture)).thenReturn(userDTO);
-        when(userService.getFullUserByUser(userDTO)).thenReturn(fullUserDTO);
+        when(userService.getFullUserByUser(userDTO, new HashSet<>())).thenReturn(fullUserDTO);
 
         FullUserDTO result = oauthService.makeUser(userDTO, "externalId123", profilePicture, OAuthProvider.google);
 
@@ -154,7 +155,7 @@ public class OAuthServiceTests {
         when(externalIdMapRepository.existsById("externalId456")).thenReturn(false);
         when(userService.existsByEmail(userDTO.email())).thenReturn(false);
         when(userService.saveUserWithProfilePicture(userDTO, profilePicture)).thenReturn(userDTO);
-        when(userService.getFullUserByUser(userDTO)).thenReturn(fullUserDTO);
+        when(userService.getFullUserByUser(userDTO, new HashSet<>())).thenReturn(fullUserDTO);
 
         FullUserDTO result = oauthService.makeUser(userDTO, "externalId456", profilePicture, OAuthProvider.apple);
 
@@ -227,7 +228,7 @@ public class OAuthServiceTests {
 
         when(userService.existsByEmail(userDTO.email())).thenReturn(false);
         when(userService.saveUserWithProfilePicture(userDTO, profilePicture)).thenReturn(userDTO);
-        when(userService.getFullUserByUser(userDTO)).thenReturn(fullUserDTO);
+        when(userService.getFullUserByUser(userDTO, new HashSet<>())).thenReturn(fullUserDTO);
 
         FullUserDTO result = oauthService.makeUser(userDTO, null, profilePicture, OAuthProvider.google);
 
@@ -273,7 +274,7 @@ public class OAuthServiceTests {
         when(externalIdMapRepository.existsById("externalId123")).thenReturn(false);
         when(userService.existsByEmail(userDTO.email())).thenReturn(false);
         when(userService.saveUserWithProfilePicture(userDTO, profilePicture)).thenReturn(userDTO);
-        when(userService.getFullUserByUser(userDTO)).thenReturn(fullUserDTO);
+        when(userService.getFullUserByUser(userDTO, new HashSet<>())).thenReturn(fullUserDTO);
 
         FullUserDTO result = oauthService.makeUser(userDTO, "externalId123", profilePicture, OAuthProvider.google);
 


### PR DESCRIPTION
- Added `visitedUsers` to these methods:
    - `UserService::getFullUserByUser()`
    - `UserService::convertUsersToFullUsers()`
All other changes simply supply `new HashSet<>()` for these arguments to start off the recursion empty, so there's no real need to review those.

Explanation:
- provided `visitedUsers` argument to pass between these methods, such that they don't re-visit the same user (similar to Leetcodes involving DFS, like in Course Schedule II where you have to detect cycles--except now, we're bullet-proofing against cycles)
- This implementation ensures we can keep the `FullUserDTO` the same, with having embedded friends' full DTOs, instead of having to convert these down to base `UserDTO`s--which could've also fixed this issue
   - This was done to ensure mobile wouldn't be affected or need to make extra API calls for friend info

- Excluded existing friend user ids from `UserService::getRecommendedFriends()` algorithm

- Fixed `UserService::getFullFriendUsersByUserId()` to re-use `FullUserDTO` properties instead of re-fetching