### PR TITLE
Event User Domain Fixes

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Models/CompositeKeys/ChatMessageLikesId.java
+++ b/src/main/java/com/danielagapov/spawn/Models/CompositeKeys/ChatMessageLikesId.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
@@ -21,4 +22,17 @@ public class ChatMessageLikesId implements Serializable {
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ChatMessageLikesId that)) return false;
+        return Objects.equals(chatMessageId, that.chatMessageId) &&
+                Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(chatMessageId, userId);
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/Models/CompositeKeys/EventUsersId.java
+++ b/src/main/java/com/danielagapov/spawn/Models/CompositeKeys/EventUsersId.java
@@ -1,12 +1,14 @@
 package com.danielagapov.spawn.Models.CompositeKeys;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
+import java.util.Objects;
 import java.util.UUID;
 
 @Embeddable
@@ -20,4 +22,17 @@ public class EventUsersId implements Serializable {
 
     @Column(name = "user_id", nullable = false)
     private UUID userId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EventUsersId that)) return false;
+        return Objects.equals(eventId, that.eventId) &&
+                Objects.equals(userId, that.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(eventId, userId);
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
@@ -1,13 +1,13 @@
 package com.danielagapov.spawn.Repositories;
 
+import com.danielagapov.spawn.Models.CompositeKeys.EventUsersId;
 import com.danielagapov.spawn.Models.EventUser;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface IEventUserRepository extends JpaRepository<EventUser, UUID> {
+public interface IEventUserRepository extends JpaRepository<EventUser, EventUsersId> {
     List<EventUser> findByEvent_Id(UUID eventId);
-
     List<EventUser> findByUser_Id(UUID userId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -325,14 +325,11 @@ public class EventService implements IEventService {
     @Override
     public ParticipationStatus getParticipationStatus(UUID eventId, UUID userId) {
         EventUsersId compositeId = new EventUsersId(eventId, userId);
-        Optional<EventUser> eventUser = eventUserRepository.findById(compositeId);
-
-        if (eventUser.isPresent()) {
-            return eventUser.get().getStatus();
-        } else {
-            return ParticipationStatus.notInvited;
-        }
+        return eventUserRepository.findById(compositeId)
+                .map(EventUser::getStatus)
+                .orElse(ParticipationStatus.notInvited);
     }
+
 
     // return type boolean represents whether the user was already invited or not
     // if false -> invites them
@@ -347,6 +344,7 @@ public class EventService implements IEventService {
             // User is already invited
             return existingEventUser.get().getStatus().equals(ParticipationStatus.invited);
         } else {
+            // Create a new invitation.
             User user = userRepository.findById(userId)
                     .orElseThrow(() -> new BaseNotFoundException(EntityType.User, userId));
             Event event = repository.findById(eventId)
@@ -362,6 +360,7 @@ public class EventService implements IEventService {
             return false;
         }
     }
+
 
     // returns the updated event, with modified participants and invited users
     // invited/participating


### PR DESCRIPTION
- Main bug fix: we were using `UUID`s to find `EventUser` entities, while they should really be identified using the composite key, `EventUsersId`
- Fixed composite key ids by implementing `.equals()` and `.hashCode()` methods
- Simplified methods in `EventService` relating to participation, using the proper composite ids
- Adjusted tests