### PR TITLE
change requirements for make-user endpoint

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
@@ -50,7 +50,7 @@ public class OAuthController {
      */
     // full path: /api/v1/oauth/sign-in?externalUserId=externalUserId&email=email
     @GetMapping("sign-in")
-    public ResponseEntity<FullUserDTO> signIn(@RequestParam("externalUserId") String externalUserId, @RequestParam("email") String email) {
+    public ResponseEntity<FullUserDTO> signIn(@RequestParam("externalUserId") String externalUserId, @RequestParam(value = "email", required = false) String email) {
         try {
             logger.log(String.format("Received sign-in request: {externalUserId: %s, email: %s}", externalUserId, email));
             return ResponseEntity.ok().body(oauthService.getUserIfExistsbyExternalId(externalUserId, email));

--- a/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
@@ -25,7 +25,6 @@ public class OAuthController {
     }
 
     /**
-     * 
      * @param principal the google oauth response
      * @return either a `UserDTO` if they're verified to already have been a Spawn user, or
      * a newly-created user if they weren't previously a Spawn user
@@ -44,9 +43,9 @@ public class OAuthController {
 
     /**
      * This method is meant to check whether an externally signed-in user through either Google or Apple
-     * already has an existing `User` created within spawn, given their external user id, which we check 
-     * against our mappings of internal ids to external ones. 
-     * 
+     * already has an existing `User` created within spawn, given their external user id, which we check
+     * against our mappings of internal ids to external ones.
+     * <p>
      * If the user is already saved within Spawn -> we return its `FullUserDTO`. Otherwise, null.
      */
     // full path: /api/v1/oauth/sign-in?externalUserId=externalUserId&email=email
@@ -61,24 +60,23 @@ public class OAuthController {
     }
 
     /**
-     * This method creates a user, given a `UserDTO` from mobile, which can be constructed through the email 
-     * given through Google, Apple, or email/pass authentication + attributes input either by default through 
+     * This method creates a user, given a `UserDTO` from mobile, which can be constructed through the email
+     * given through Google, Apple, or email/pass authentication + attributes input either by default through
      * these providers, such as full name & pfp, or supplied by the user (i.e. overwritten by provider, or new).
-     * 
-     * For profile pictures specifically, there's an optional argument, `profilePicture`, which will take a raw 
+     * <p>
+     * For profile pictures specifically, there's an optional argument, `profilePicture`, which will take a raw
      * byte file to overwrite/write the profile picture to the user, by saving it to the S3Service
-     * 
-     * Another argument is the `externalUserId`, which should be optional, since a user could be created 
+     * <p>
+     * Another argument is the `externalUserId`, which should be optional, since a user could be created
      * without the use of an external provider (i.e. Google or Apple), through our own email/pass authentication.
-     * 
      */
     // full path: /api/v1/oauth/make-user
     @PostMapping("make-user")
-    public ResponseEntity<FullUserDTO> makeUser(@RequestBody UserDTO userDTO, @RequestParam("externalUserId") String externalUserId, @RequestParam(value="profilePicture", required=false) byte[] profilePicture, @RequestParam(value = "provider", required = false) OAuthProvider provider) {
+    public ResponseEntity<FullUserDTO> makeUser(@RequestBody UserDTO userDTO, @RequestParam(value = "externalUserId") String externalUserId, @RequestParam(value = "profilePicture", required = false) byte[] profilePicture, @RequestParam(value = "provider") OAuthProvider provider) {
         try {
             logger.log(String.format("Received make-user request: {userDTO: %s, externalUserId: %s, provider: %s}", userDTO, externalUserId, provider));
-           FullUserDTO user = oauthService.makeUser(userDTO, externalUserId, profilePicture, provider);
-           return ResponseEntity.ok().body(user);
+            FullUserDTO user = oauthService.makeUser(userDTO, externalUserId, profilePicture, provider);
+            return ResponseEntity.ok().body(user);
         } catch (Exception e) {
             return ResponseEntity.internalServerError().body(null);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/OAuthController.java
@@ -61,14 +61,13 @@ public class OAuthController {
 
     /**
      * This method creates a user, given a `UserDTO` from mobile, which can be constructed through the email
-     * given through Google, Apple, or email/pass authentication + attributes input either by default through
+     * given through Google, Apple, or by default through
      * these providers, such as full name & pfp, or supplied by the user (i.e. overwritten by provider, or new).
      * <p>
      * For profile pictures specifically, there's an optional argument, `profilePicture`, which will take a raw
      * byte file to overwrite/write the profile picture to the user, by saving it to the S3Service
      * <p>
-     * Another argument is the `externalUserId`, which should be optional, since a user could be created
-     * without the use of an external provider (i.e. Google or Apple), through our own email/pass authentication.
+     * Another argument is the `externalUserId`, which is a unique identifier for a user used by the external provider chosen
      */
     // full path: /api/v1/oauth/make-user
     @PostMapping("make-user")

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -91,19 +91,7 @@ public class OAuthService implements IOAuthService {
             logger.log("Unexpected error while fetching user by externalUserId (" + externalUserId + ") : " + e.getMessage());
             throw e;
         }
-
-        if (mapping == null) {
-            // if not (signed in through external provider, but no external id <> user id mapping -> try finding by email
-            try {
-                return userService.getFullUserByEmail(email);
-            } catch (DataAccessException e) {
-                logger.log("Database error while fetching user by email(" + email + "): " + e.getMessage());
-                throw e;
-            } catch (Exception e) {
-                logger.log("Unexpected error while fetching user by email(" + email + "): " + e.getMessage());
-                throw e;
-            }
-        } else {
+        if (mapping != null) {
             // if there is already a mapping (Spawn account exists, given externalUserId) -> get the associated `FullUserDTO`
             try {
                 return getFullUserDTO(mapping.getUser().getId());
@@ -115,6 +103,20 @@ public class OAuthService implements IOAuthService {
                 throw e;
             }
         }
+        if (email != null) {
+            // if not (signed in through external provider, but no external id <> user id mapping -> try finding by email
+            try {
+                return userService.getFullUserByEmail(email);
+            } catch (DataAccessException e) {
+                logger.log("Database error while fetching user by email(" + email + "): " + e.getMessage());
+                throw e;
+            } catch (Exception e) {
+                logger.log("Unexpected error while fetching user by email(" + email + "): " + e.getMessage());
+                throw e;
+            }
+        }
+        // No existing user was found
+        return null;
     }
 
     /**

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -53,7 +53,7 @@ public class OAuthService implements IOAuthService {
                 logger.log(String.format("Existing user detected in makeUser, mapping already exists: {user: %s, externalUserId: %s}", userDTO.email(), externalUserId));
                 return userService.getFullUserByEmail(userDTO.email());
             }
-            if (userService.existsByEmail(userDTO.email())) {
+            if (userDTO.email() != null && userService.existsByEmail(userDTO.email())) {
                 logger.log(String.format("Existing user detected in makeUser, email already exists: {user: %s, email: %s}", userDTO.email(), userDTO.email()));
                 return userService.getFullUserByEmail(userDTO.email());
             }
@@ -61,11 +61,11 @@ public class OAuthService implements IOAuthService {
             // user dto -> entity & save user
             logger.log(String.format("Making user: {userDTO: %s}", userDTO));
             userDTO = userService.saveUserWithProfilePicture(userDTO, profilePicture);
-            if (externalUserId != null) {
-                // create and save mapping, if the user was created externally through Google or Apple
-                logger.log(String.format("External user detected, saving mapping: {externalUserId: %s, userDTO: %s}", externalUserId, userDTO));
-                saveMapping(externalUserId, userDTO, provider);
-            }
+
+            // create and save mapping
+            logger.log(String.format("External user detected, saving mapping: {externalUserId: %s, userDTO: %s}", externalUserId, userDTO));
+            createAndSaveMapping(externalUserId, userDTO, provider);
+
             FullUserDTO fullUserDTO = userService.getFullUserByUser(userDTO, new HashSet<>());
             logger.log(String.format("Returning FullUserDTO of newly made user: {fullUserDTO: %s}", fullUserDTO));
             return fullUserDTO;
@@ -198,7 +198,7 @@ public class OAuthService implements IOAuthService {
         }
     }
 
-    private void saveMapping(String externalUserId, IOnboardedUserDTO userDTO, OAuthProvider provider) {
+    private void createAndSaveMapping(String externalUserId, IOnboardedUserDTO userDTO, OAuthProvider provider) {
         try {
             User user;
             if (userDTO instanceof FullUserDTO) {


### PR DESCRIPTION
For #180.

For apple oauth, the only necessary change is to remove the requirement for email in the sign-in endpoint and only try checking if a user exists by email, when email is not null.

For the make-user endpoint, there is no longer any reason for the `externalId ` argument to not be required, since email+pass authentication will be done at a separate endpoint. Additionally, there is no reason for the `provider` argument to not be required; it should always be one of "google" or "apple". This will be a breaking change if not already provided from Mobile.