### PR TITLE
Allow POST to BetaAccessSignUp

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
@@ -27,12 +27,10 @@ public class SecurityConfig {
                     return configuration;
                 }))
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/v1/betaAccessSignUp/records", "/api/v1/betaAccessSignUp/emails").authenticated()
                         .anyRequest().permitAll()
                 )
-                .csrf(AbstractHttpConfigurer::disable)
-                .oauth2Login(oauth2 -> {
-                    oauth2.successHandler((request, response, authentication) -> response.sendRedirect("/api/v1/oauth/google/sign-in"));
-                });
+                .csrf(AbstractHttpConfigurer::disable);
         return http.build();
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Controllers/BetaAccessSignUpController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/BetaAccessSignUpController.java
@@ -37,13 +37,13 @@ public class BetaAccessSignUpController {
         }
     }
 
-    // full path: /api/v1/betaAccessSignUp/
+    // full path: /api/v1/betaAccessSignUp/records
 
     /**
      * @return returns all signed-up users, for our own internal reference,
      * without having to check the database
      */
-    @GetMapping
+    @GetMapping("records")
     public ResponseEntity<List<BetaAccessSignUpDTO>> getAllRecords() {
         try {
             return new ResponseEntity<>(service.getAllBetaAccessSignUpRecords(), HttpStatus.OK);
@@ -58,6 +58,7 @@ public class BetaAccessSignUpController {
 
     /**
      * Sign-up endpoint for creating a new record
+     *
      * @param dto constructed via front-end form submission
      * @return back the DTO after being persisted into our database if successful.
      * Otherwise, we'll throw a 500 (INTERNAL_SERVER_ERROR).


### PR DESCRIPTION
Allow POST to BetaAccessSignUp

Block GET requests to BetaAccessSignUp

I changed `GET /api/v1/betaAccessSignUp/` => `GET /api/v1/betaAccessSignUp/records` so I can allow a POST request through but block the GET request