### PR TITLE
Change Custom Header name

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
@@ -105,7 +105,7 @@ public class AuthController {
     private HttpHeaders makeHeadersForTokens(String username) {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + jwtService.generateAccessToken(username));
-        headers.set("Refresh Token", jwtService.generateRefreshToken(username));
+        headers.set("X-Refresh-Token", jwtService.generateRefreshToken(username));
         return headers;
     }
 }


### PR DESCRIPTION
I had a space in a custom header name ("Refresh Token") that I think might have been causing issues.