### PR TITLE
2 Bug Fixes + Optionals for DB Queries

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Exceptions/Base/BaseNotFoundException.java
+++ b/src/main/java/com/danielagapov/spawn/Exceptions/Base/BaseNotFoundException.java
@@ -5,10 +5,14 @@ import com.danielagapov.spawn.Enums.EntityType;
 import java.util.UUID;
 
 public class BaseNotFoundException extends RuntimeException {
+    public BaseNotFoundException(EntityType et) {
+        super(et +  " entity not found");
+    }
     public BaseNotFoundException(EntityType et, UUID id) {
         super(et +  " entity not found with ID: " + id);
     }
     public BaseNotFoundException(EntityType et, String username) {
         super(et +  " entity not found with username: " + username);
     }
+
 }

--- a/src/main/java/com/danielagapov/spawn/Exceptions/Base/BaseNotFoundException.java
+++ b/src/main/java/com/danielagapov/spawn/Exceptions/Base/BaseNotFoundException.java
@@ -11,8 +11,14 @@ public class BaseNotFoundException extends RuntimeException {
     public BaseNotFoundException(EntityType et, UUID id) {
         super(et +  " entity not found with ID: " + id);
     }
-    public BaseNotFoundException(EntityType et, String username) {
-        super(et +  " entity not found with username: " + username);
-    }
 
+    /**
+     *
+     * @param et The entity type that could not be found.
+     * @param identifier this could be something like a user's email or username
+     * @param identifierType to indicate if it's an email, username, or something else in the print statement.
+     */
+    public BaseNotFoundException(EntityType et, String identifier, String identifierType) {
+        super(et +  " entity not found with " + identifierType + ": " + identifier);
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/Repositories/IFriendTagRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IFriendTagRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
@@ -16,5 +17,5 @@ public interface IFriendTagRepository extends JpaRepository<FriendTag, UUID> {
     List<FriendTag> findByOwnerId(@Param("ownerId") UUID ownerId);
 
     @Query("SELECT ft From FriendTag ft WHERE ft.ownerId = :ownerId AND ft.isEveryone = true")
-    FriendTag findEveryoneTagByOwnerId(@Param("ownerId") UUID ownerId);
+    Optional<FriendTag> findEveryoneTagByOwnerId(@Param("ownerId") UUID ownerId);
 }

--- a/src/main/java/com/danielagapov/spawn/Repositories/IUserRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IUserRepository.java
@@ -7,15 +7,16 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface IUserRepository extends JpaRepository<User, UUID> {
     // The JpaRepository interface already includes methods like save() and findById()
     // Find
-    User findByEmail(String email);
+    Optional<User> findByEmail(String email);
 
-    User findByUsername(String username);
+    Optional<User> findByUsername(String username);
 
     // Exist
     boolean existsByUsername(String username);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -564,15 +564,9 @@ public class EventService implements IEventService {
 
         // use creator to get the friend tag that relates the requesting user to see
         // which friend tag they've placed them in
-        FriendTagDTO pertainingFriendTag = friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.getCreatorUserId());
-
-        // -> for now, we handle tie-breaks (user has same friend within two friend tags) in whichever way (just choose one)
-        if (pertainingFriendTag == null) {
-            return "#1D3D3D"; // Default color if no tag exists
-        }
-        // using that friend tag, grab its colorHexCode property to return from this method
-
-        return pertainingFriendTag.getColorHexCode();
+        return friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.getCreatorUserId())
+                .map(FriendTagDTO::getColorHexCode)
+                .orElse("#1D3D3D"); // Default color if no tag exists
     }
 
     @Override

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -564,7 +564,7 @@ public class EventService implements IEventService {
 
         // use creator to get the friend tag that relates the requesting user to see
         // which friend tag they've placed them in
-        return Optional.ofNullable(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.getCreatorUserId()))
+        return Optional.ofNullable(friendTagService.getPertainingFriendTagBetweenUsers(requestingUserId, eventDTO.getCreatorUserId()))
                 .flatMap(optional -> optional)  // This will flatten the Optional<Optional<FriendTagDTO>> to Optional<FriendTagDTO>
                 .map(FriendTagDTO::getColorHexCode)
                 .orElse("#1D3D3D"); // Default color if no tag exists or if result is null

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -564,9 +564,10 @@ public class EventService implements IEventService {
 
         // use creator to get the friend tag that relates the requesting user to see
         // which friend tag they've placed them in
-        return friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.getCreatorUserId())
+        return Optional.ofNullable(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, eventDTO.getCreatorUserId()))
+                .flatMap(optional -> optional)  // This will flatten the Optional<Optional<FriendTagDTO>> to Optional<FriendTagDTO>
                 .map(FriendTagDTO::getColorHexCode)
-                .orElse("#1D3D3D"); // Default color if no tag exists
+                .orElse("#1D3D3D"); // Default color if no tag exists or if result is null
     }
 
     @Override

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -262,7 +262,7 @@ public class FriendTagService implements IFriendTagService {
     /// friend inside, even if they've placed them in multiple friend tags
     /// -> currently, on the product side, we don't specify a rule for which should take precedence.
     @Override
-    public Optional<FriendTagDTO> getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId) {
+    public Optional<FriendTagDTO> getPertainingFriendTagBetweenUsers(UUID ownerUserId, UUID friendUserId) {
         // Fetch all friend tags for the owner
         ArrayList<FriendTagDTO> friendTags = new ArrayList<>(getFriendTagsByOwnerId(ownerUserId).stream()
                 // Filter to include only friend tags where friendUserId exists in friendUserIds

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -262,7 +262,7 @@ public class FriendTagService implements IFriendTagService {
     /// friend inside, even if they've placed them in multiple friend tags
     /// -> currently, on the product side, we don't specify a rule for which should take precedence.
     @Override
-    public FriendTagDTO getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId) {
+    public Optional<FriendTagDTO> getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId) {
         // Fetch all friend tags for the owner
         ArrayList<FriendTagDTO> friendTags = new ArrayList<>(getFriendTagsByOwnerId(ownerUserId).stream()
                 // Filter to include only friend tags where friendUserId exists in friendUserIds
@@ -274,12 +274,7 @@ public class FriendTagService implements IFriendTagService {
 
         // arbitrarily grab the first tag that isn't the 'everyone' tag
         try {
-            Optional<FriendTagDTO> friendTag = friendTags.stream().findFirst();
-            if (friendTag.isPresent()) { // just null-checking
-                return friendTag.get();
-            } else {
-                throw new BaseNotFoundException(EntityType.FriendTag, friendUserId);
-            }
+            return friendTags.stream().findFirst();
         } catch (Exception e) {
             logger.log(e.getMessage());
             throw e;

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
@@ -26,7 +26,7 @@ public interface IFriendTagService {
     List<UUID> getFriendTagIdsByOwnerUserId(UUID id);
 
     // friend-related:
-    Optional<FriendTagDTO> getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId);
+    Optional<FriendTagDTO> getPertainingFriendTagBetweenUsers(UUID ownerUserId, UUID friendUserId);
 
     void saveUserToFriendTag(UUID id, UUID userId);
 

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/IFriendTagService.java
@@ -5,6 +5,7 @@ import com.danielagapov.spawn.DTOs.FriendTag.FullFriendTagDTO;
 import com.danielagapov.spawn.DTOs.User.FullUserDTO;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface IFriendTagService {
@@ -25,7 +26,7 @@ public interface IFriendTagService {
     List<UUID> getFriendTagIdsByOwnerUserId(UUID id);
 
     // friend-related:
-    FriendTagDTO getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId);
+    Optional<FriendTagDTO> getPertainingFriendTagByUserIds(UUID ownerUserId, UUID friendUserId);
 
     void saveUserToFriendTag(UUID id, UUID userId);
 

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -362,10 +362,13 @@ public class UserService implements IUserService {
     public List<UserDTO> getFriendsByUserId(UUID userId) {
         try {
             // Get the FriendTags associated with the user (assuming userId represents the owner of friend tags)
-            FriendTag everyoneTag = friendTagRepository.findEveryoneTagByOwnerId(userId);
-            if (everyoneTag == null) {
+            Optional<FriendTag> optionalEveryoneTag = friendTagRepository.findEveryoneTagByOwnerId(userId);
+
+            if (optionalEveryoneTag.isEmpty()) {
                 return List.of(); // empty list of friends
             }
+
+            FriendTag everyoneTag = optionalEveryoneTag.get();
 
             // Retrieve the friends for each FriendTag and return as a flattened list
             List<UserDTO> friends = getFriendsByFriendTagId(everyoneTag.getId());

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -394,11 +394,14 @@ public class UserService implements IUserService {
                 return;
             }
 
-            UUID userEveryoneTagId = friendTagRepository.findEveryoneTagByOwnerId(userId).getId();
-            friendTagService.saveUserToFriendTag(userEveryoneTagId, friendId);
+            Optional<FriendTag> userEveryoneTag = friendTagRepository.findEveryoneTagByOwnerId(userId);
+            userEveryoneTag.ifPresent(tag ->
+                friendTagService.saveUserToFriendTag(tag.getId(), friendId));
 
-            UUID friendEveryoneTagId = friendTagRepository.findEveryoneTagByOwnerId(userId).getId();
-            friendTagService.saveUserToFriendTag(friendEveryoneTagId, userId);
+
+            Optional<FriendTag> friendEveryoneTag = friendTagRepository.findEveryoneTagByOwnerId(friendId);
+            friendEveryoneTag.ifPresent(tag ->
+                    friendTagService.saveUserToFriendTag(tag.getId(), userId));
         } catch (Exception e) {
             logger.log(e.getMessage());
             throw e;

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -288,8 +288,8 @@ public class UserService implements IUserService {
     @Override
     public FullUserDTO getFullUserByEmail(String email) {
         try {
-            User user = repository.findByEmail(email);
-            return user == null ? null : getFullUserById(user.getId());
+            User user = repository.findByEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.User, email));
+            return getFullUserById(user.getId());
         } catch (Exception e) {
             logger.log(e.getMessage());
             throw e;
@@ -616,10 +616,7 @@ public class UserService implements IUserService {
     @Override
     public FullUserDTO getFullUserByUsername(String username) {
         try {
-            User user = repository.findByUsername(username);
-            if (user == null) {
-                throw new BaseNotFoundException(EntityType.User, username);
-            }
+            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username));
             return getFullUserById(user.getId());
         } catch (Exception e) {
             logger.log(e.getMessage());
@@ -636,7 +633,7 @@ public class UserService implements IUserService {
     public void verifyUserByUsername(String username) {
         try {
             logger.log("Marking user as verified " + username);
-            User user = repository.findByUsername(username);
+            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username));
             user.setVerified(true);
             repository.save(user);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -288,7 +288,7 @@ public class UserService implements IUserService {
     @Override
     public FullUserDTO getFullUserByEmail(String email) {
         try {
-            User user = repository.findByEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.User, email));
+            User user = repository.findByEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.User, email, "email"));
             return getFullUserById(user.getId());
         } catch (Exception e) {
             logger.log(e.getMessage());
@@ -616,7 +616,7 @@ public class UserService implements IUserService {
     @Override
     public FullUserDTO getFullUserByUsername(String username) {
         try {
-            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username));
+            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username, "username"));
             return getFullUserById(user.getId());
         } catch (Exception e) {
             logger.log(e.getMessage());
@@ -633,7 +633,7 @@ public class UserService implements IUserService {
     public void verifyUserByUsername(String username) {
         try {
             logger.log("Marking user as verified " + username);
-            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username));
+            User user = repository.findByUsername(username).orElseThrow(() -> new BaseNotFoundException(EntityType.User, username, "username"));
             user.setVerified(true);
             repository.save(user);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Services/UserDetails/UserInfoService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/UserDetails/UserInfoService.java
@@ -25,10 +25,6 @@ public class UserInfoService implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        User user = repository.findByUsername(username);
-        if (user == null) {
-            throw new UsernameNotFoundException(username);
-        }
 
         return new UserInfo(user.getUsername(), "user.getPassword()");
     }

--- a/src/main/java/com/danielagapov/spawn/Services/UserDetails/UserInfoService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/UserDetails/UserInfoService.java
@@ -25,6 +25,7 @@ public class UserInfoService implements UserDetailsService {
      */
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = repository.findByUsername(username).orElseThrow(() -> new UsernameNotFoundException(username));
 
         return new UserInfo(user.getUsername(), "user.getPassword()");
     }

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
@@ -456,7 +456,7 @@ public class EventServiceTests {
         FriendTagDTO friendTag = mock(FriendTagDTO.class);
         when(friendTag.getColorHexCode()).thenReturn("#123456");
         when(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, event.getCreator().getId()))
-                .thenReturn(friendTag);
+                .thenReturn(Optional.of(friendTag));
 
         // Stub participation status lookups
         when(eventUserRepository.existsById(compositeId)).thenReturn(true);
@@ -740,7 +740,7 @@ public class EventServiceTests {
 
         FriendTagDTO dummyTag = mock(FriendTagDTO.class);
         when(dummyTag.getColorHexCode()).thenReturn("#DUMMY");
-        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(dummyTag);
+        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(Optional.of(dummyTag));
 
         List<FullFeedEventDTO> fullEvents = eventService.getFullEventsInvitedTo(userId);
 
@@ -788,7 +788,7 @@ public class EventServiceTests {
         UUID requestingUserId = UUID.randomUUID();
         FriendTagDTO friendTag = mock(FriendTagDTO.class);
         when(friendTag.getColorHexCode()).thenReturn("#ABCDEF");
-        when(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, creatorId)).thenReturn(friendTag);
+        when(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, creatorId)).thenReturn(Optional.of(friendTag));
 
         String colorHex = eventService.getFriendTagColorHexCodeForRequestingUser(eventDTO, requestingUserId);
 

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/EventServiceTests.java
@@ -407,7 +407,7 @@ public class EventServiceTests {
         when(userService.convertUsersToFullUsers(any(), eq(new HashSet<>()))).thenReturn(List.of());
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
         // Stub friend tag lookup; for events without a requesting user, no friend tag is applied.
-        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(null);
+        when(friendTagService.getPertainingFriendTagBetweenUsers(any(UUID.class), any(UUID.class))).thenReturn(null);
 
         // To ensure getParticipationStatus does not throw, stub existsById and findByEvent_Id.
         when(eventUserRepository.existsById(any(EventUsersId.class))).thenReturn(true);
@@ -455,7 +455,7 @@ public class EventServiceTests {
         // Stub friend tag lookup
         FriendTagDTO friendTag = mock(FriendTagDTO.class);
         when(friendTag.getColorHexCode()).thenReturn("#123456");
-        when(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, event.getCreator().getId()))
+        when(friendTagService.getPertainingFriendTagBetweenUsers(requestingUserId, event.getCreator().getId()))
                 .thenReturn(Optional.of(friendTag));
 
         // Stub participation status lookups
@@ -740,7 +740,7 @@ public class EventServiceTests {
 
         FriendTagDTO dummyTag = mock(FriendTagDTO.class);
         when(dummyTag.getColorHexCode()).thenReturn("#DUMMY");
-        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(Optional.of(dummyTag));
+        when(friendTagService.getPertainingFriendTagBetweenUsers(any(UUID.class), any(UUID.class))).thenReturn(Optional.of(dummyTag));
 
         List<FullFeedEventDTO> fullEvents = eventService.getFullEventsInvitedTo(userId);
 
@@ -788,7 +788,7 @@ public class EventServiceTests {
         UUID requestingUserId = UUID.randomUUID();
         FriendTagDTO friendTag = mock(FriendTagDTO.class);
         when(friendTag.getColorHexCode()).thenReturn("#ABCDEF");
-        when(friendTagService.getPertainingFriendTagByUserIds(requestingUserId, creatorId)).thenReturn(Optional.of(friendTag));
+        when(friendTagService.getPertainingFriendTagBetweenUsers(requestingUserId, creatorId)).thenReturn(Optional.of(friendTag));
 
         String colorHex = eventService.getFriendTagColorHexCodeForRequestingUser(eventDTO, requestingUserId);
 
@@ -821,7 +821,7 @@ public class EventServiceTests {
         dummyEU.setStatus(ParticipationStatus.invited);
         when(eventUserRepository.findByEvent_Id(any(UUID.class))).thenReturn(List.of(dummyEU));
         // Stub friend tag lookup to return null (i.e. no friend tag applies).
-        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(null);
+        when(friendTagService.getPertainingFriendTagBetweenUsers(any(UUID.class), any(UUID.class))).thenReturn(null);
 
         List<FullFeedEventDTO> fullEvents = eventService.convertEventsToFullFeedEvents(events, requestingUserId);
         assertNotNull(fullEvents, "The converted list should not be null");
@@ -846,7 +846,7 @@ public class EventServiceTests {
         when(chatMessageService.getFullChatMessagesByEventId(any(UUID.class))).thenReturn(List.of());
 
         // Stub friend tag lookup to return null (self-owned accent)
-        when(friendTagService.getPertainingFriendTagByUserIds(any(UUID.class), any(UUID.class))).thenReturn(null);
+        when(friendTagService.getPertainingFriendTagBetweenUsers(any(UUID.class), any(UUID.class))).thenReturn(null);
 
         // Stub participation lookup with a valid EventUser and User
         when(eventUserRepository.existsById(compositeId)).thenReturn(true);


### PR DESCRIPTION
- Wrapped singular entity DB queries with `Optional<>`
- New `BaseNotFoundException(EntityType et, String identifier, String identifierType)` exception, to specify `identifierType`, instead of being confined to `username` only (we can now use email or something else)

## Bug Fixes:
- `UserService:: saveFriendToUser()` bug should be fixed (in Slack, #testing-qa)
![image](https://github.com/user-attachments/assets/f8138c7f-edec-431e-9214-f58345ef2b34)
- `FriendTagService::getPertainingFriendTagByUserIds()`
![image](https://github.com/user-attachments/assets/7c658477-edca-40c7-8837-8f9995a4cf3f)


