### PR TITLE
Returning 400 errors for missing id params in endpoints

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
@@ -74,6 +74,7 @@ public class ChatMessageController {
     // full path: /api/v1/chatMessages/{id}
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteChatMessage(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             boolean isDeleted = chatMessageService.deleteChatMessageById(id);
             if (isDeleted) {
@@ -91,6 +92,7 @@ public class ChatMessageController {
     // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
     @PostMapping("/{chatMessageId}/likes/{userId}")
     public ResponseEntity<ChatMessageLikesDTO> createChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
+        if (chatMessageId == null || userId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(chatMessageService.createChatMessageLike(chatMessageId, userId), HttpStatus.CREATED);
         } catch (BaseNotFoundException e) {
@@ -103,6 +105,7 @@ public class ChatMessageController {
     // full path: /api/v1/chatMessages/{chatMessageId}/likes
     @GetMapping("/{chatMessageId}/likes")
     public ResponseEntity<List<UserDTO>> getChatMessageLikes(@PathVariable UUID chatMessageId) {
+        if (chatMessageId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(chatMessageService.getChatMessageLikes(chatMessageId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -115,6 +118,7 @@ public class ChatMessageController {
     // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
     @DeleteMapping("/{chatMessageId}/likes/{userId}")
     public ResponseEntity<Void> deleteChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
+        if (chatMessageId == null || userId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             chatMessageService.deleteChatMessageLike(chatMessageId, userId);
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -25,6 +25,7 @@ public class FriendRequestController {
     // full path: /api/v1/friend-requests/incoming/{userId}
     @GetMapping("incoming/{userId}")
     public ResponseEntity<List<FetchFriendRequestDTO>> getIncomingFriendRequestsByUserId(@PathVariable UUID userId) {
+        if (userId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(friendRequestService.getIncomingFetchFriendRequestsByUserId(userId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -47,10 +48,11 @@ public class FriendRequestController {
     // full path: /api/v1/friend-requests/{friendRequestId}?friendRequestAction={accept/reject}
     @PutMapping("{friendRequestId}")
     public ResponseEntity<Void> friendRequestAction(@PathVariable UUID friendRequestId, @RequestParam FriendRequestAction friendRequestAction) {
+        if (friendRequestId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
-            if (friendRequestAction == FriendRequestAction.accept && friendRequestId != null) {
+            if (friendRequestAction == FriendRequestAction.accept) {
                 friendRequestService.acceptFriendRequest(friendRequestId);
-            } else if (friendRequestAction == FriendRequestAction.reject && friendRequestId != null) {
+            } else if (friendRequestAction == FriendRequestAction.reject) {
                 friendRequestService.deleteFriendRequest(friendRequestId);
             } else {
                 // deal with null/invalid argument for `friendRequestAction`

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -42,6 +42,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/{id}?full=full
     @GetMapping("{id}")
     public ResponseEntity<AbstractFriendTagDTO> getFriendTag(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (full) {
                 return new ResponseEntity<>(friendTagService.getFullFriendTagById(id), HttpStatus.OK);
@@ -80,6 +81,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/{id}
     @PutMapping("{id}")
     public ResponseEntity<FriendTagDTO> replaceFriendTag(@RequestBody FriendTagDTO newFriendTag, @PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(friendTagService.replaceFriendTag(newFriendTag, id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -92,6 +94,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/{id}
     @DeleteMapping("{id}")
     public ResponseEntity<Void> deleteFriendTag(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             boolean isDeleted = friendTagService.deleteFriendTagById(id);
             if (isDeleted) {
@@ -109,6 +112,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/owner/{ownerId}?full=full
     @GetMapping("owner/{ownerId}")
     public ResponseEntity<List<? extends AbstractFriendTagDTO>> getFriendTagsByOwnerId(@PathVariable UUID ownerId, @RequestParam(value = "full", required = false) boolean full) {
+        if (ownerId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (full) {
                 return new ResponseEntity<>(friendTagService.convertFriendTagsToFullFriendTags(friendTagService.getFriendTagsByOwnerId(ownerId)), HttpStatus.OK);
@@ -125,6 +129,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/{id}?friendTagAction={addFriend/removeFriend}&userId=userId
     @PostMapping("{id}")
     public ResponseEntity<Void> modifyFriendTagFriends(@PathVariable UUID id, @RequestParam FriendTagAction friendTagAction, @RequestParam UUID userId) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (friendTagAction == FriendTagAction.addFriend) {
                 friendTagService.saveUserToFriendTag(id, userId);
@@ -154,6 +159,7 @@ public class FriendTagController {
      */
     @GetMapping("{friendTagsForFriend}")
     public ResponseEntity<List<FullFriendTagDTO>> getFriendTagsForFriend(@RequestParam UUID ownerUserId, @RequestParam UUID friendUserId) {
+        if (ownerUserId == null || friendUserId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(friendTagService.getPertainingFullFriendTagsForFriend(ownerUserId, friendUserId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -172,6 +178,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/friendsNotAddedToTag/{friendTagId}
     @GetMapping("friendsNotAddedToTag/{friendTagId}")
     public ResponseEntity<List<FullUserDTO>> getFriendsNotAddedToTag(@PathVariable UUID friendTagId) {
+        if (friendTagId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(friendTagService.getFriendsNotAddedToTag(friendTagId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -181,8 +188,10 @@ public class FriendTagController {
         }
     }
 
+    // full path: /api/v1/friendTags/addUserToTags/{ownerUserId}?friendUserId=friendUserId
     @GetMapping("addUserToTags/{ownerUserId}")
     public ResponseEntity<List<FullFriendTagDTO>> getTagsNotAddedToFriend(@PathVariable UUID ownerUserId, @RequestParam UUID friendUserId) {
+        if (ownerUserId == null || friendUserId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(friendTagService.getTagsNotAddedToFriend(ownerUserId, friendUserId), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -192,8 +201,10 @@ public class FriendTagController {
         }
     }
 
+    // full path: /api/v1/friendTags/addUserToTags?friendUserId=friendUserId
     @PostMapping("addUserToTags")
     public ResponseEntity<Void> addUserToTags(@RequestBody List<UUID> friendTagIds, @RequestParam UUID friendUserId) {
+        if (friendUserId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (!friendTagIds.isEmpty()) {
                 friendTagService.addFriendToFriendTags(friendTagIds, friendUserId);
@@ -210,6 +221,7 @@ public class FriendTagController {
     // full path: /api/v1/friendTags/bulkAddFriendsToTag
     @PostMapping("bulkAddFriendsToTag")
     public ResponseEntity<Void> bulkAddFriendsToTag(@RequestBody List<FullUserDTO> friends, @RequestParam UUID friendTagId) {
+        if (friendTagId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             friendTagService.saveUsersToFriendTag(friendTagId, friends);
             return new ResponseEntity<>(HttpStatus.OK);

--- a/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
@@ -34,6 +34,7 @@ public class LocationController {
     // full path: /api/v1/locations/{id}
     @GetMapping("{id}")
     public ResponseEntity<LocationDTO> getLocationById(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(locationService.getLocationById(id), HttpStatus.OK);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/ReportController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ReportController.java
@@ -46,8 +46,9 @@ public class ReportController {
     }
 
     // full path: /api/v1/reports/{reportId}?resolution=<ResolutionStatus>
-    @PostMapping("{reportId}")
+    @PutMapping("{reportId}")
     public ResponseEntity<ReportedContentDTO> resolveReport(@PathVariable UUID reportId, @RequestParam("resolution") ResolutionStatus resolution) {
+        if (reportId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             ReportedContentDTO report = reportService.resolveReport(reportId, resolution);
             return ResponseEntity.ok(report);
@@ -61,6 +62,7 @@ public class ReportController {
     // full path: /api/v1/reports/reporters/{reporterId}
     @GetMapping("reporter/{reporterId}")
     public ResponseEntity<List<ReportedContentDTO>> getReportsByReporter(@PathVariable UUID reporterId) {
+        if (reporterId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             List<ReportedContentDTO> reports = reportService.getReportsByReporterId(reporterId);
             return ResponseEntity.ok(reports);
@@ -74,6 +76,7 @@ public class ReportController {
     // full path: /api/v1/reports/reported-users/{contentOwnerId}
     @GetMapping("{contentOwnerId}")
     public ResponseEntity<List<ReportedContentDTO>> getReportsByContentOwner(@PathVariable UUID contentOwnerId) {
+        if (contentOwnerId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             List<ReportedContentDTO> reports = reportService.getReportsByContentOwnerId(contentOwnerId);
             return ResponseEntity.ok(reports);
@@ -87,6 +90,7 @@ public class ReportController {
     // full path: /api/v1/reports/{reportId}
     @DeleteMapping("{reportId}")
     public ResponseEntity<Void> deleteReport(@PathVariable UUID reportId) {
+        if (reportId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             reportService.deleteReportById(reportId);
             return ResponseEntity.noContent().build();
@@ -100,6 +104,7 @@ public class ReportController {
     // full path: /api/v1/reports/{reportId}
     @GetMapping("{reportId}")
     public ResponseEntity<ReportedContentDTO> getReportById(@PathVariable UUID reportId) {
+        if (reportId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             ReportedContentDTO report = reportService.getReportById(reportId);
             return ResponseEntity.ok(report);

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -42,6 +42,7 @@ public class UserController {
     // full path: /api/v1/users/{id}?full=full
     @GetMapping("{id}")
     public ResponseEntity<AbstractUserDTO> getUser(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (full) {
                 return new ResponseEntity<>(userService.getFullUserById(id), HttpStatus.OK);
@@ -58,6 +59,7 @@ public class UserController {
     // full path: /api/v1/users/friends/{id}
     @GetMapping("friends/{id}")
     public ResponseEntity<List<? extends AbstractUserDTO>> getUserFriends(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(userService.getFullFriendUsersByUserId(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -80,6 +82,7 @@ public class UserController {
     // full path: /api/v1/users/friendTag/{tagId}?full=full
     @GetMapping("friendTag/{tagId}")
     public ResponseEntity<List<? extends AbstractUserDTO>> getUsersByFriendTag(@PathVariable UUID tagId, @RequestParam(value = "full", required = false) boolean full) {
+        if (tagId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             if (full) {
                 return new ResponseEntity<>(userService.convertUsersToFullUsers(userService.getUsersByTagId(tagId), new HashSet<>()), HttpStatus.OK);
@@ -106,6 +109,7 @@ public class UserController {
     // full path: /api/v1/users/{id}
     @PutMapping("{id}")
     public ResponseEntity<UserDTO> replaceUser(@RequestBody UserDTO newUser, @PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(userService.replaceUser(newUser, id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -118,6 +122,7 @@ public class UserController {
     // full path: /api/v1/users/{id}
     @DeleteMapping("{id}")
     public ResponseEntity<Void> deleteUser(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             boolean isDeleted = userService.deleteUserById(id);
             if (isDeleted) {
@@ -135,6 +140,7 @@ public class UserController {
     // full path: /api/v1/users/recommended-friends/{id}
     @GetMapping("recommended-friends/{id}")
     public ResponseEntity<List<RecommendedFriendUserDTO>> getRecommendedFriends(@PathVariable UUID id) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(userService.getRecommendedFriendsForUserId(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
@@ -147,6 +153,7 @@ public class UserController {
     // full path: /api/v1/users/update-pfp/{id}
     @PatchMapping("update-pfp/{id}")
     public ResponseEntity<UserDTO> updatePfp(@PathVariable UUID id, @RequestBody byte[] file) {
+        if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
             return new ResponseEntity<>(s3Service.updateProfilePicture(file, id), HttpStatus.OK);
         } catch (Exception e) {


### PR DESCRIPTION
Could prevent downstream errors to do with null id params in service methods, or to repo method calls. 

Just bullet-proofing our controllers, to not let null ids through to service classes. 

In `EventController`, I removed unused:
- endpoint (with path     // full path: /api/v1/events/{id}?full=full&requestingUserId=requestingUserId)
- logger