### PR TITLE
OAuth BaseUserDTO refactor

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
@@ -47,11 +47,11 @@ public class AuthController {
     public ResponseEntity<?> signIn(@RequestParam("externalUserId") String externalUserId, @RequestParam(value = "email", required = false) String email) {
         try {
             logger.log(String.format("Received sign-in request: {externalUserId: %s, email: %s}", externalUserId, email));
-            Optional<FullUserDTO> optionalDTO = oauthService.getUserIfExistsbyExternalId(externalUserId, email);
+            Optional<BaseUserDTO> optionalDTO = oauthService.getUserIfExistsbyExternalId(externalUserId, email);
             if (optionalDTO.isPresent()) {
-                FullUserDTO fullUserDTO = optionalDTO.get();
-                HttpHeaders headers = makeHeadersForTokens(fullUserDTO.getUsername());
-                return ResponseEntity.ok().headers(headers).body(fullUserDTO);
+                BaseUserDTO baseUserDTO = optionalDTO.get();
+                HttpHeaders headers = makeHeadersForTokens(baseUserDTO.getUsername());
+                return ResponseEntity.ok().headers(headers).body(baseUserDTO);
             }
             return ResponseEntity.ok().body(null);
         } catch (IncorrectProviderException e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/AuthController.java
@@ -74,13 +74,13 @@ public class AuthController {
      */
     // full path: /api/v1/auth/make-user
     @PostMapping("make-user")
-    public ResponseEntity<FullUserDTO> makeUser(@RequestBody UserCreationDTO userCreationDTO,
+    public ResponseEntity<BaseUserDTO> makeUser(@RequestBody UserCreationDTO userCreationDTO,
                                                 @RequestParam("externalUserId") String externalUserId,
                                                 @RequestParam(value = "provider") OAuthProvider provider) {
         try {
             logger.log(String.format("Received make-user request: {userDTO: %s, externalUserId: %s, provider: %s}",
                     userCreationDTO, externalUserId, provider));
-            FullUserDTO user = oauthService.createUser(userCreationDTO, externalUserId, provider);
+            BaseUserDTO user = oauthService.createUser(userCreationDTO, externalUserId, provider);
             HttpHeaders headers = makeHeadersForTokens(userCreationDTO.getUsername());
             return ResponseEntity.ok().headers(headers).body(user);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Mappers/UserMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/UserMapper.java
@@ -66,4 +66,16 @@ public class UserMapper {
                 .collect(Collectors.toList());
     }
 
+    public static BaseUserDTO toBaseDTO(UserDTO user) {
+        return new BaseUserDTO(
+                user.getId(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.getEmail(),
+                user.getUsername(),
+                user.getBio(),
+                user.getProfilePicture()
+        );
+    }
+
 }

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
@@ -1,5 +1,6 @@
 package com.danielagapov.spawn.Services.OAuth;
 
+import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.FullUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserCreationDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
@@ -39,5 +40,5 @@ public interface IOAuthService {
      * @param email          user email
      * @return a FullUserDTO if user exists, null otherwise
      */
-    Optional<FullUserDTO> getUserIfExistsbyExternalId(String externalUserId, String email);
+    Optional<BaseUserDTO> getUserIfExistsbyExternalId(String externalUserId, String email);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/IOAuthService.java
@@ -1,7 +1,6 @@
 package com.danielagapov.spawn.Services.OAuth;
 
 import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
-import com.danielagapov.spawn.DTOs.User.FullUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserCreationDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
 import com.danielagapov.spawn.Enums.OAuthProvider;
@@ -21,7 +20,7 @@ public interface IOAuthService {
      * @return FullUserDTO of the newly created user
      */
     // TODO: refactor to return UserDTO instead of Full since the new user won't have friends/events anyway
-    FullUserDTO makeUser(UserDTO user, String externalUserId, byte[] profilePicture, OAuthProvider provider);
+    BaseUserDTO makeUser(UserDTO user, String externalUserId, byte[] profilePicture, OAuthProvider provider);
 
 
     /**
@@ -30,7 +29,7 @@ public interface IOAuthService {
      * @param provider        provider indicating Google or Apple
      * @return returns back the fully-created user, after it goes through the `makeUser()` method
      */
-    FullUserDTO createUser(UserCreationDTO userCreationDTO, String externalUserId, OAuthProvider provider);
+    BaseUserDTO createUser(UserCreationDTO userCreationDTO, String externalUserId, OAuthProvider provider);
 
     /**
      * Given an external user id from an oauth provider, check whether it belongs it a user account.

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -1,7 +1,6 @@
 package com.danielagapov.spawn.Services.OAuth;
 
 import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
-import com.danielagapov.spawn.DTOs.User.FullUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserCreationDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
 import com.danielagapov.spawn.Enums.EntityType;
@@ -18,7 +17,6 @@ import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-import java.util.UUID;
 
 @Service
 public class OAuthService implements IOAuthService {
@@ -55,11 +53,13 @@ public class OAuthService implements IOAuthService {
             // TODO: temporary solution
             if (mappingExistsByExternalId(externalUserId)) {
                 logger.log(String.format("Existing user detected in makeUser, mapping already exists: {user: %s, externalUserId: %s}", userDTO.getEmail(), externalUserId));
-                return userService.getFullUserById(getMapping(externalUserId).getUser().getId());
+                User user = getMapping(externalUserId).getUser();
+                return UserMapper.toDTO(user);
             }
             if (userDTO.getEmail() != null && userService.existsByEmail(userDTO.getEmail())) {
                 logger.log(String.format("Existing user detected in makeUser, email already exists: {user: %s, email: %s}", userDTO.getEmail(), userDTO.getEmail()));
-                return userService.getFullUserByEmail(userDTO.getEmail());
+                User user = getMappingByUserEmail(userDTO.getEmail()).getUser();
+                return UserMapper.toDTO(user);
             }
 
             // user dto -> entity & save user
@@ -92,7 +92,7 @@ public class OAuthService implements IOAuthService {
             User user = getMapping(externalUserId).getUser();
             return Optional.of(UserMapper.toDTO(user));
         } else if (existsByEmail) { // A Spawn account exists with this email but not with the external id which indicates a sign-in with incorrect provider
-            UserIdExternalIdMap externalIdMap = externalIdMapRepository.findByUserEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.ExternalIdMap, email, "email"));
+            UserIdExternalIdMap externalIdMap = getMappingByUserEmail(email);
             String provider = String.valueOf(externalIdMap.getProvider()).equals("google") ? "Google" : "Apple";
             throw new IncorrectProviderException("The email: " + email + " is already associated to a " + provider + " account. Please login through " + provider + " instead");
         } else { // No account exists for this external id or email
@@ -118,22 +118,6 @@ public class OAuthService implements IOAuthService {
         }
     }
 
-
-    private FullUserDTO getFullUserDTO(UUID externalUserId) {
-        try {
-            return userService.getFullUserById(externalUserId);
-        } catch (BaseNotFoundException e) {
-            logger.log("User not found while fetching full user DTO: " + e.getMessage());
-            throw e;
-        } catch (DataAccessException e) {
-            logger.log("Database error while fetching full user DTO: " + e.getMessage());
-            throw e;
-        } catch (Exception e) {
-            logger.log("Unexpected error while fetching full user DTO: " + e.getMessage());
-            throw e;
-        }
-    }
-
     private void createAndSaveMapping(String externalUserId, UserDTO userDTO, OAuthProvider provider) {
         try {
             User user = UserMapper.toEntity(userDTO);
@@ -145,5 +129,9 @@ public class OAuthService implements IOAuthService {
             logger.log(e.getMessage());
             throw e;
         }
+    }
+
+    private UserIdExternalIdMap getMappingByUserEmail(String email) {
+        return externalIdMapRepository.findByUserEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.ExternalIdMap, email, "email"));
     }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -1,5 +1,6 @@
 package com.danielagapov.spawn.Services.OAuth;
 
+import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.FullUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserCreationDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
@@ -84,13 +85,13 @@ public class OAuthService implements IOAuthService {
 
 
     @Override
-    public Optional<FullUserDTO> getUserIfExistsbyExternalId(String externalUserId, String email) {
+    public Optional<BaseUserDTO> getUserIfExistsbyExternalId(String externalUserId, String email) {
         boolean existsByExternalId = mappingExistsByExternalId(externalUserId);
         boolean existsByEmail = userService.existsByEmail(email);
 
         if (existsByExternalId) { // A Spawn account exists with this external id, return the associated `FullUserDTO`
             User user = getMapping(externalUserId).getUser();
-            return Optional.of(userService.getFullUserByUserEntity(user));
+            return Optional.of(UserMapper.toDTO(user));
         } else if (existsByEmail) { // A Spawn account exists with this email but not with the external id which indicates a sign-in with incorrect provider
             UserIdExternalIdMap externalIdMap = externalIdMapRepository.findByUserEmail(email).orElseThrow(() -> new BaseNotFoundException(EntityType.ExternalIdMap, email, "email"));
             String provider = String.valueOf(externalIdMap.getProvider()).equals("google") ? "Google" : "Apple";

--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -17,7 +17,6 @@ import com.danielagapov.spawn.Services.User.IUserService;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -34,7 +33,7 @@ public class OAuthService implements IOAuthService {
     }
 
     @Override
-    public FullUserDTO createUser(UserCreationDTO userCreationDTO, String externalUserId, OAuthProvider provider) {
+    public BaseUserDTO createUser(UserCreationDTO userCreationDTO, String externalUserId, OAuthProvider provider) {
         UserDTO newUser = new UserDTO(
                 userCreationDTO.getId(),
                 null,
@@ -51,7 +50,7 @@ public class OAuthService implements IOAuthService {
     }
 
     @Override
-    public FullUserDTO makeUser(UserDTO userDTO, String externalUserId, byte[] profilePicture, OAuthProvider provider) {
+    public BaseUserDTO makeUser(UserDTO userDTO, String externalUserId, byte[] profilePicture, OAuthProvider provider) {
         try {
             // TODO: temporary solution
             if (mappingExistsByExternalId(externalUserId)) {
@@ -71,9 +70,9 @@ public class OAuthService implements IOAuthService {
             logger.log(String.format("External user detected, saving mapping: {externalUserId: %s, userDTO: %s}", externalUserId, userDTO));
             createAndSaveMapping(externalUserId, userDTO, provider);
 
-            FullUserDTO fullUserDTO = userService.getFullUserByUser(userDTO, new HashSet<>());
-            logger.log(String.format("Returning FullUserDTO of newly made user: {fullUserDTO: %s}", fullUserDTO));
-            return fullUserDTO;
+            BaseUserDTO baseUserDTO = UserMapper.toBaseDTO(userDTO);
+            logger.log(String.format("Returning BaseUserDTO of newly made user: {baseUserDTO: %s}", baseUserDTO));
+            return baseUserDTO;
         } catch (DataAccessException e) {
             logger.log("Database error while creating user: " + e.getMessage());
             throw e;


### PR DESCRIPTION
As discussed on Slack, refactored the endpoints `AuthController::makeUser` and `AuthController::signIn` to return `BaseUserDTO`s instead of `FullUserDTO`s. Also updated the tests accordingly.