### PR TITLE
Endpoint Mobile Usage Documentation

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
@@ -27,10 +27,7 @@ public class ChatMessageController {
     }
 
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/chatMessages?full=full
     @GetMapping
@@ -47,10 +44,7 @@ public class ChatMessageController {
     }
 
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/chatMessages/{id}?full=full
     @GetMapping("/{id}")
@@ -79,10 +73,7 @@ public class ChatMessageController {
     }
 
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -105,10 +96,7 @@ public class ChatMessageController {
     }
 
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -125,10 +113,7 @@ public class ChatMessageController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -147,10 +132,7 @@ public class ChatMessageController {
 
 
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")

--- a/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ChatMessageController.java
@@ -26,6 +26,12 @@ public class ChatMessageController {
         this.chatMessageService = chatMessageService;
     }
 
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/chatMessages?full=full
     @GetMapping
     public ResponseEntity<List<? extends AbstractChatMessageDTO>> getChatMessages(@RequestParam(value = "full", required = false) boolean full) {
@@ -40,6 +46,12 @@ public class ChatMessageController {
         }
     }
 
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/chatMessages/{id}?full=full
     @GetMapping("/{id}")
     public ResponseEntity<AbstractChatMessageDTO> getChatMessage(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
@@ -56,12 +68,6 @@ public class ChatMessageController {
         }
     }
 
-    // full path: /api/v1/chatMessages/mock-endpoint
-    @GetMapping("/mock-endpoint")
-    public ResponseEntity<String> getMockEndpoint() {
-        return new ResponseEntity<>("This is the mock endpoint for chatMessages. Everything is working with it.", HttpStatus.OK);
-    }
-
     // full path: /api/v1/chatMessages
     @PostMapping
     public ResponseEntity<ChatMessageDTO> createChatMessage(@RequestBody CreateChatMessageDTO newChatMessage) {
@@ -72,6 +78,14 @@ public class ChatMessageController {
         }
     }
 
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/chatMessages/{id}
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteChatMessage(@PathVariable UUID id) {
@@ -90,6 +104,14 @@ public class ChatMessageController {
         }
     }
 
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
     @PostMapping("/{chatMessageId}/likes/{userId}")
     public ResponseEntity<ChatMessageLikesDTO> createChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
@@ -103,6 +125,13 @@ public class ChatMessageController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/chatMessages/{chatMessageId}/likes
     @GetMapping("/{chatMessageId}/likes")
     public ResponseEntity<List<BaseUserDTO>> getChatMessageLikes(@PathVariable UUID chatMessageId) {
@@ -116,7 +145,15 @@ public class ChatMessageController {
         }
     }
 
-    // full path: /api/v1/chatMessages/{chatMessageId}/likes/{userId}
+
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     @DeleteMapping("/{chatMessageId}/likes/{userId}")
     public ResponseEntity<Void> deleteChatMessageLike(@PathVariable UUID chatMessageId, @PathVariable UUID userId) {
         if (chatMessageId == null || userId == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -29,10 +29,7 @@ public class EventController {
         this.userService = userService;
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events?full=full
     @GetMapping
@@ -48,10 +45,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently." +
             "This may become a feature, as Owen has suggested, " +
             "with showing a friend's recent events.")
@@ -107,10 +101,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -127,10 +118,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -152,10 +140,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{id}/users?full=full
     @GetMapping("{id}/users")
@@ -178,10 +163,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{eventId}/participating?userId={userid}
     @GetMapping("{eventId}/participating")
@@ -201,10 +183,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{eventId}/invited?userId={userid}
     @GetMapping("{eventId}/invited")
@@ -240,10 +219,7 @@ public class EventController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now. 
+    // TL;DR: Don't remove this endpoint; it may become useful. 
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/invitedEvents/{userId}?full=full
     @GetMapping("invitedEvents/{userId}")

--- a/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/EventController.java
@@ -4,15 +4,12 @@ import com.danielagapov.spawn.DTOs.Event.AbstractEventDTO;
 import com.danielagapov.spawn.DTOs.Event.EventCreationDTO;
 import com.danielagapov.spawn.DTOs.Event.EventDTO;
 import com.danielagapov.spawn.DTOs.Event.FullFeedEventDTO;
-import com.danielagapov.spawn.DTOs.User.AbstractUserDTO;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
-import com.danielagapov.spawn.Exceptions.EventsNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
-import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
+import com.danielagapov.spawn.Exceptions.EventsNotFoundException;
 import com.danielagapov.spawn.Services.Event.IEventService;
 import com.danielagapov.spawn.Services.User.IUserService;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -32,6 +29,11 @@ public class EventController {
         this.userService = userService;
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events?full=full
     @GetMapping
     public ResponseEntity<List<? extends AbstractEventDTO>> getEvents(@RequestParam(value = "full", required = false) boolean full) {
@@ -45,7 +47,14 @@ public class EventController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
-  
+
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently." +
+            "This may become a feature, as Owen has suggested, " +
+            "with showing a friend's recent events.")
     // full path: /api/v1/events/user/{creatorUserId}?full=full
     @GetMapping("user/{creatorUserId}")
     public ResponseEntity<?> getEventsCreatedByUserId(@PathVariable UUID creatorUserId, @RequestParam(value = "full", required = false) boolean full) {
@@ -87,13 +96,6 @@ public class EventController {
         }
     }
 
-    // full path: /api/v1/events/mock-endpoint
-    @GetMapping("mock-endpoint")
-    public ResponseEntity<String> getMockEndpoint() {
-        return new ResponseEntity<>("This is the mock endpoint for events. Everything is working with it.",
-                HttpStatus.OK);
-    }
-
     // full path: /api/v1/events
     @PostMapping
     public ResponseEntity<AbstractEventDTO> createEvent(@RequestBody EventCreationDTO eventCreationDTO) {
@@ -105,6 +107,13 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/events/{id}
     @PutMapping("{id}")
     public ResponseEntity<?> replaceEvent(@RequestBody EventDTO newEvent, @PathVariable UUID id) {
@@ -118,6 +127,13 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/events/{id}
     @DeleteMapping("{id}")
     public ResponseEntity<?> deleteEvent(@PathVariable UUID id) {
@@ -136,6 +152,11 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{id}/users?full=full
     @GetMapping("{id}/users")
     public ResponseEntity<?> getUsersParticipatingInEvent(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
@@ -157,6 +178,11 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{eventId}/participating?userId={userid}
     @GetMapping("{eventId}/participating")
     public ResponseEntity<?> isUserParticipating(@PathVariable UUID eventId, @RequestParam UUID userId) {
@@ -175,6 +201,11 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/{eventId}/invited?userId={userid}
     @GetMapping("{eventId}/invited")
     public ResponseEntity<?> isUserInvited(@PathVariable UUID eventId, @RequestParam UUID userId) {
@@ -209,6 +240,11 @@ public class EventController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now. 
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/events/invitedEvents/{userId}?full=full
     @GetMapping("invitedEvents/{userId}")
     // need this `? extends AbstractEventDTO` instead of simply `AbstractEventDTO`, because of this error:

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -25,10 +25,7 @@ public class FriendTagController {
         this.friendTagService = friendTagService;
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/friendTags?full=full
     @GetMapping
@@ -44,10 +41,7 @@ public class FriendTagController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/friendTags/{id}?full=full
     @GetMapping("{id}")

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendTagController.java
@@ -25,6 +25,11 @@ public class FriendTagController {
         this.friendTagService = friendTagService;
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/friendTags?full=full
     @GetMapping
     public ResponseEntity<List<? extends AbstractFriendTagDTO>> getFriendTags(@RequestParam(value = "full", required = false) boolean full) {
@@ -39,6 +44,11 @@ public class FriendTagController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/friendTags/{id}?full=full
     @GetMapping("{id}")
     public ResponseEntity<AbstractFriendTagDTO> getFriendTag(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
@@ -51,16 +61,6 @@ public class FriendTagController {
             }
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    // full path: /api/v1/friendTags/mock-endpoint
-    @GetMapping("mock-endpoint")
-    public ResponseEntity<String> getMockEndpoint() {
-        try {
-            return new ResponseEntity<>("This is the mock endpoint for friendTags. Everything is working with it.", HttpStatus.OK);
         } catch (Exception e) {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
@@ -21,6 +21,11 @@ public class LocationController {
         this.locationService = locationService;
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/locations
     @GetMapping
     public ResponseEntity<List<LocationDTO>> getLocations() {
@@ -31,6 +36,11 @@ public class LocationController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/locations/{id}
     @GetMapping("{id}")
     public ResponseEntity<LocationDTO> getLocationById(@PathVariable UUID id) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/LocationController.java
@@ -21,10 +21,7 @@ public class LocationController {
         this.locationService = locationService;
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/locations
     @GetMapping
@@ -36,10 +33,7 @@ public class LocationController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/locations/{id}
     @GetMapping("{id}")

--- a/src/main/java/com/danielagapov/spawn/Controllers/ReportController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/ReportController.java
@@ -20,6 +20,9 @@ import java.util.UUID;
 public class ReportController {
     private final IReportContentService reportService;
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports?reportType=?<ReportType>&contentType=<EntityType>
     @GetMapping
     public ResponseEntity<List<ReportedContentDTO>> getReports(
@@ -34,6 +37,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports
     @PostMapping
     public ResponseEntity<ReportedContentDTO> createReport(@RequestBody ReportedContentDTO report) {
@@ -45,6 +51,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports/{reportId}?resolution=<ResolutionStatus>
     @PutMapping("{reportId}")
     public ResponseEntity<ReportedContentDTO> resolveReport(@PathVariable UUID reportId, @RequestParam("resolution") ResolutionStatus resolution) {
@@ -59,6 +68,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports/reporters/{reporterId}
     @GetMapping("reporter/{reporterId}")
     public ResponseEntity<List<ReportedContentDTO>> getReportsByReporter(@PathVariable UUID reporterId) {
@@ -73,6 +85,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports/reported-users/{contentOwnerId}
     @GetMapping("{contentOwnerId}")
     public ResponseEntity<List<ReportedContentDTO>> getReportsByContentOwner(@PathVariable UUID contentOwnerId) {
@@ -87,6 +102,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports/{reportId}
     @DeleteMapping("{reportId}")
     public ResponseEntity<Void> deleteReport(@PathVariable UUID reportId) {
@@ -101,6 +119,9 @@ public class ReportController {
         }
     }
 
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/reports/{reportId}
     @GetMapping("{reportId}")
     public ResponseEntity<ReportedContentDTO> getReportById(@PathVariable UUID reportId) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -28,10 +28,7 @@ public class UserController {
         this.logger = logger;
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users?full=full
     @GetMapping
@@ -47,10 +44,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/{id}?full=full
     @GetMapping("{id}")
@@ -82,10 +76,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/friendTag/{tagId}?full=full
     @GetMapping("friendTag/{tagId}")
@@ -104,10 +95,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users
     @PostMapping
@@ -119,10 +107,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
@@ -170,10 +155,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/update-pfp/{id}
     @PatchMapping("update-pfp/{id}")
@@ -186,10 +168,7 @@ public class UserController {
         }
     }
 
-    // Despite this not currently being used, let's not delete it.
-    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
-    // wasn't being used -> so I removed it, but had to add it back for a new feature.
-    // So, let's consider removing it in the future, but keep for now.
+    // TL;DR: Don't remove this endpoint; it may become useful.
     @Deprecated(since = "Not being used on mobile currently. " +
             "Pending mobile feature implementation, per:" +
             "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")

--- a/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/UserController.java
@@ -28,6 +28,11 @@ public class UserController {
         this.logger = logger;
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users?full=full
     @GetMapping
     public ResponseEntity<List<? extends AbstractUserDTO>> getUsers(@RequestParam(value = "full", required = false) boolean full) {
@@ -42,6 +47,11 @@ public class UserController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/{id}?full=full
     @GetMapping("{id}")
     public ResponseEntity<AbstractUserDTO> getUser(@PathVariable UUID id, @RequestParam(value = "full", required = false) boolean full) {
@@ -72,16 +82,11 @@ public class UserController {
         }
     }
 
-    // full path: /api/v1/users/mock-endpoint
-    @GetMapping("mock-endpoint")
-    public ResponseEntity<String> getMockEndpoint() {
-        try {
-            return new ResponseEntity<>("This is the mock endpoint for users. Everything is working with it.", HttpStatus.OK);
-        } catch (Exception e) {
-            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/friendTag/{tagId}?full=full
     @GetMapping("friendTag/{tagId}")
     public ResponseEntity<List<? extends AbstractUserDTO>> getUsersByFriendTag(@PathVariable UUID tagId, @RequestParam(value = "full", required = false) boolean full) {
@@ -99,6 +104,11 @@ public class UserController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users
     @PostMapping
     public ResponseEntity<UserDTO> createUser(@RequestParam("user") UserDTO newUser, @RequestParam("pfp") byte[] file) {
@@ -109,6 +119,13 @@ public class UserController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/users/{id}
     @PutMapping("{id}")
     public ResponseEntity<UserDTO> replaceUser(@RequestBody UserDTO newUser, @PathVariable UUID id) {
@@ -153,6 +170,11 @@ public class UserController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently.")
     // full path: /api/v1/users/update-pfp/{id}
     @PatchMapping("update-pfp/{id}")
     public ResponseEntity<UserDTO> updatePfp(@PathVariable UUID id, @RequestBody byte[] file) {
@@ -164,6 +186,13 @@ public class UserController {
         }
     }
 
+    // Despite this not currently being used, let's not delete it.
+    // Recently, I noticed that our `EventController::getFullEventById()` endpoint
+    // wasn't being used -> so I removed it, but had to add it back for a new feature.
+    // So, let's consider removing it in the future, but keep for now.
+    @Deprecated(since = "Not being used on mobile currently. " +
+            "Pending mobile feature implementation, per:" +
+            "https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142")
     // full path: /api/v1/users/default-pfp
     @GetMapping("default-pfp")
     public ResponseEntity<String> getDefaultProfilePicture() {


### PR DESCRIPTION
- Removed all mock endpoints
- Documented unused endpoints with `@Deprecated`
    - If those endpoints will soon be used by mobile, as documented in [this mobile issue](https://github.com/Daggerpov/Spawn-App-iOS-SwiftUI/issues/142), then they mention that