### PR TITLE
Events by Friend Tag bug fix

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Repositories/IEventRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IEventRepository.java
@@ -2,6 +2,8 @@ package com.danielagapov.spawn.Repositories;
 
 import com.danielagapov.spawn.Models.Event;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,4 +18,12 @@ public interface IEventRepository extends JpaRepository<Event, UUID> {
 
     // finds events that have been created by users, whose ids are in the `creatorIds` list
     List<Event> findByCreatorIdIn(List<UUID> creatorIds);
+
+    @Query("SELECT e FROM Event e " +
+            "JOIN e.creator c " +
+            "JOIN UserFriendTag f ON f.friend.id = c.id " +  // Get friends of the friend tag owner
+            "JOIN EventUser eu ON eu.event.id = e.id " +  // Get users invited to the event
+            "WHERE f.friendTag.id = :friendTagId " +
+            "AND eu.user.id = :invitedUserId")
+    List<Event> getEventsInvitedToWithFriendTagId(@Param("friendTagId") UUID friendTagId, @Param("invitedUserId") UUID invitedUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/EventService.java
@@ -408,6 +408,20 @@ public class EventService implements IEventService {
     }
 
     @Override
+    public List<EventDTO> getEventsInvitedToByFriendTagId(UUID friendTagId, UUID requestingUserId) {
+        try {
+            List<Event> events = repository.getEventsInvitedToWithFriendTagId(friendTagId, requestingUserId);
+            return getEventDTOs(events);
+        } catch (DataAccessException e) {
+            logger.error(e.getMessage());
+            throw new BaseNotFoundException(EntityType.FriendTag, friendTagId);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+            throw e;
+        }
+    }
+
+    @Override
     public List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id) {
         List<EventUser> eventUsers = eventUserRepository.findByUser_Id(id);
 
@@ -498,7 +512,7 @@ public class EventService implements IEventService {
         try {
             UUID requestingUserId = friendTagService.getFriendTagById(friendTagFilterId).getOwnerUserId();
             List<FullFeedEventDTO> eventsCreated = convertEventsToFullFeedSelfOwnedEvents(getEventsByOwnerId(requestingUserId), requestingUserId);
-            List<FullFeedEventDTO> eventsByFriendTagFilter = convertEventsToFullFeedEvents(getEventsByFriendTagId(friendTagFilterId), requestingUserId);
+            List<FullFeedEventDTO> eventsByFriendTagFilter = convertEventsToFullFeedEvents(getEventsInvitedToByFriendTagId(friendTagFilterId, requestingUserId), requestingUserId);
 
             // Remove expired events
             removeExpiredEvents(eventsCreated);

--- a/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Event/IEventService.java
@@ -13,34 +13,53 @@ import java.util.UUID;
 
 public interface IEventService {
     List<EventDTO> getAllEvents();
-    
+
     // CRUD operations:
     EventDTO getEventById(UUID id);
+
     AbstractEventDTO saveEvent(AbstractEventDTO event);
+
     AbstractEventDTO createEvent(EventCreationDTO eventCreationDTO);
+
     EventDTO replaceEvent(EventDTO event, UUID eventId);
+
     boolean deleteEventById(UUID id);
 
     // Participation-related methods:
     List<UserDTO> getParticipatingUsersByEventId(UUID id);
+
     ParticipationStatus getParticipationStatus(UUID eventId, UUID userId);
+
     boolean inviteUser(UUID eventId, UUID userId);
+
     // returns back the updated event dto, with participants and invited users updated:
     FullFeedEventDTO toggleParticipation(UUID eventId, UUID userId);
+
     List<EventDTO> getEventsInvitedTo(UUID id);
+
+    List<EventDTO> getEventsInvitedToByFriendTagId(UUID friendTagId, UUID requestingUserId);
 
     // Get 'Full' Event Methods:
     List<FullFeedEventDTO> getFullEventsInvitedTo(UUID id);
+
     FullFeedEventDTO getFullEventByEvent(EventDTO event, UUID requestingUserId, Set<UUID> visitedEvents);
+
     List<FullFeedEventDTO> getAllFullEvents();
+
     FullFeedEventDTO getFullEventById(UUID id, UUID requestingUserId);
+
     List<FullFeedEventDTO> convertEventsToFullFeedEvents(List<EventDTO> events, UUID requestingUserId);
+
     List<FullFeedEventDTO> convertEventsToFullFeedSelfOwnedEvents(List<EventDTO> events, UUID requestingUserId);
+
     List<FullFeedEventDTO> getFeedEvents(UUID requestingUserId);
+
     List<FullFeedEventDTO> getFilteredFeedEventsByFriendTagId(UUID friendTagFilterId);
 
     // Additional Methods:
     List<EventDTO> getEventsByFriendTagId(UUID friendTagId);
+
     List<EventDTO> getEventsByOwnerId(UUID creatorUserId);
+
     String getFriendTagColorHexCodeForRequestingUser(EventDTO eventDTO, UUID requestingUserId);
 }


### PR DESCRIPTION
Per Slack: "it seems the bug is due to the way events are fetched through `EventController::getEventsByFriendTag()`. Currently, `getEventsByFriendTag()` is getting events that a user's friends has created, when it should be events that a user has been invited to."

With this PR, we are now getting events that a user has been invited by all their friends who belong to the specified friend tag. This logic is done at the database level with a single query (`IEventRepository::getEventsInvitedToWithFriendTagId`).