### PR TITLE
Add chat message ordering

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Repositories/IChatMessageRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IChatMessageRepository.java
@@ -10,4 +10,6 @@ import java.util.UUID;
 @Repository
 public interface IChatMessageRepository extends JpaRepository<ChatMessage, UUID> {
     List<ChatMessage> getChatMessagesByEventId(UUID eventId);
+
+    List<ChatMessage> getChatMessagesByEventIdOrderByTimestampDesc(UUID eventId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/ChatMessage/ChatMessageService.java
@@ -6,7 +6,7 @@ import com.danielagapov.spawn.DTOs.ChatMessage.CreateChatMessageDTO;
 import com.danielagapov.spawn.DTOs.ChatMessage.FullEventChatMessageDTO;
 import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.Enums.EntityType;
-import com.danielagapov.spawn.Enums.ParticipationStatus;
+import com.danielagapov.spawn.Events.NewCommentNotificationEvent;
 import com.danielagapov.spawn.Exceptions.Base.BaseDeleteException;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BaseSaveException;
@@ -16,17 +16,22 @@ import com.danielagapov.spawn.Exceptions.Logger.ILogger;
 import com.danielagapov.spawn.Mappers.ChatMessageLikesMapper;
 import com.danielagapov.spawn.Mappers.ChatMessageMapper;
 import com.danielagapov.spawn.Mappers.UserMapper;
-import com.danielagapov.spawn.Models.*;
+import com.danielagapov.spawn.Models.ChatMessage;
+import com.danielagapov.spawn.Models.ChatMessageLikes;
+import com.danielagapov.spawn.Models.Event;
+import com.danielagapov.spawn.Models.User;
 import com.danielagapov.spawn.Repositories.*;
 import com.danielagapov.spawn.Services.FriendTag.IFriendTagService;
 import com.danielagapov.spawn.Services.User.IUserService;
-import com.danielagapov.spawn.Events.NewCommentNotificationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -173,7 +178,7 @@ public class ChatMessageService implements IChatMessageService {
     public List<UUID> getChatMessageIdsByEventId(UUID eventId) {
         try {
             // Retrieve all chat messages for the specified event
-            List<ChatMessage> chatMessages = chatMessageRepository.getChatMessagesByEventId(eventId);
+            List<ChatMessage> chatMessages = chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId);
 
             // Extract the IDs of the chat messages and return them as a list
             return chatMessages.stream()
@@ -265,7 +270,7 @@ public class ChatMessageService implements IChatMessageService {
     @Override
     public List<ChatMessageDTO> getChatMessagesByEventId(UUID eventId) {
         try {
-            List<ChatMessage> chatMessages = chatMessageRepository.getChatMessagesByEventId(eventId);
+            List<ChatMessage> chatMessages = chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId);
 
             return chatMessages.stream()
                     .map(chatMessage -> {

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/ChatMessageServiceTests.java
@@ -14,11 +14,7 @@ import com.danielagapov.spawn.Models.ChatMessage;
 import com.danielagapov.spawn.Models.ChatMessageLikes;
 import com.danielagapov.spawn.Models.Event;
 import com.danielagapov.spawn.Models.User;
-import com.danielagapov.spawn.Repositories.IChatMessageLikesRepository;
-import com.danielagapov.spawn.Repositories.IChatMessageRepository;
-import com.danielagapov.spawn.Repositories.IEventRepository;
-import com.danielagapov.spawn.Repositories.IUserRepository;
-import com.danielagapov.spawn.Repositories.IEventUserRepository;
+import com.danielagapov.spawn.Repositories.*;
 import com.danielagapov.spawn.Services.ChatMessage.ChatMessageService;
 import com.danielagapov.spawn.Services.Event.IEventService;
 import com.danielagapov.spawn.Services.FriendTag.IFriendTagService;
@@ -63,10 +59,10 @@ public class ChatMessageServiceTests {
 
     @Mock
     private ILogger logger;
-    
+
     @Mock
     private IEventUserRepository eventUserRepository;
-    
+
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
@@ -296,7 +292,7 @@ public class ChatMessageServiceTests {
         chatMessage1.setEvent(dummyEvent);
         chatMessage2.setEvent(dummyEvent);
         List<ChatMessage> messages = List.of(chatMessage1, chatMessage2);
-        when(chatMessageRepository.getChatMessagesByEventId(eventId)).thenReturn(messages);
+        when(chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId)).thenReturn(messages);
         when(chatMessageRepository.findById(id1)).thenReturn(Optional.of(chatMessage1));
         when(chatMessageRepository.findById(id2)).thenReturn(Optional.of(chatMessage2));
         when(chatMessageLikesRepository.findByChatMessage(chatMessage1)).thenReturn(new ArrayList<>());
@@ -362,7 +358,7 @@ public class ChatMessageServiceTests {
         chatMessage1.setEvent(eventForMessages);
         chatMessage2.setEvent(eventForMessages);
         List<ChatMessage> messages = List.of(chatMessage1, chatMessage2);
-        when(chatMessageRepository.getChatMessagesByEventId(eventId)).thenReturn(messages);
+        when(chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId)).thenReturn(messages);
         List<UUID> ids = chatMessageService.getChatMessageIdsByEventId(eventId);
         assertNotNull(ids);
         assertEquals(2, ids.size());
@@ -479,7 +475,7 @@ public class ChatMessageServiceTests {
         chatMessage1.setEvent(dummyEvent);
         chatMessage2.setEvent(dummyEvent);
         List<ChatMessage> messages = List.of(chatMessage1, chatMessage2);
-        when(chatMessageRepository.getChatMessagesByEventId(eventId)).thenReturn(messages);
+        when(chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId)).thenReturn(messages);
         when(chatMessageRepository.findById(id1)).thenReturn(Optional.of(chatMessage1));
         when(chatMessageRepository.findById(id2)).thenReturn(Optional.of(chatMessage2));
         when(chatMessageLikesRepository.findByChatMessage(chatMessage1)).thenReturn(new ArrayList<>());
@@ -496,7 +492,7 @@ public class ChatMessageServiceTests {
         UUID eventId = UUID.randomUUID();
         DataAccessException dae = new DataAccessException("DB error") {
         };
-        when(chatMessageRepository.getChatMessagesByEventId(eventId)).thenThrow(dae);
+        when(chatMessageRepository.getChatMessagesByEventIdOrderByTimestampDesc(eventId)).thenThrow(dae);
         assertThrows(BasesNotFoundException.class, () -> chatMessageService.getChatMessagesByEventId(eventId));
         verify(logger, times(1)).error(dae.getMessage());
     }


### PR DESCRIPTION
Previously chat messages were unordered when returned by any event endpoint. Now they are ordered from newest -> oldest.

So, in the app, when you click on an event, new chat messages will be on top, older chat messages are at the bottom.

Used DB level sorting