### PR TITLE
Fix 500 error when deleting users by cascading NotificationPreferences removal

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Models/User.java
+++ b/src/main/java/com/danielagapov/spawn/Models/User.java
@@ -1,9 +1,6 @@
 package com.danielagapov.spawn.Models;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,6 +34,9 @@ public class User implements Serializable {
     private String password;
     private boolean verified;
     private Date dateCreated;
+    @OneToOne(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private NotificationPreferences notificationPreferences;
+
 
     public User(UUID id, String username, String profilePictureUrlString, String firstName, String lastName, String bio, String email) {
         this.id = id;


### PR DESCRIPTION
- Introduced a bidirectional @OneToOne relationship in the User entity
- Added cascade = CascadeType.REMOVE and orphanRemoval = true to automatically delete related NotificationPreferences

Resolves #293 