### PR TITLE
Redis Caching - Events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <artifactId>apns</artifactId>
             <version>1.0.0.Beta6</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <version>3.2.5</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/BetaAccessSignUpService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/BetaAccessSignUp/BetaAccessSignUpService.java
@@ -9,8 +9,10 @@ import com.danielagapov.spawn.Mappers.BetaAccessSignUpMapper;
 import com.danielagapov.spawn.Models.BetaAccessSignUp;
 import com.danielagapov.spawn.Repositories.IBetaAccessSignUpRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
+import org.springframework.cache.annotation.Cacheable;
 
 import java.util.List;
 import java.util.UUID;
@@ -33,6 +35,7 @@ public class BetaAccessSignUpService implements IBetaAccessSignUpService {
      * @return all beta access sign up record DTOs
      */
     @Override
+    @Cacheable(value = "betaAccessRecords")
     public List<BetaAccessSignUpDTO> getAllBetaAccessSignUpRecords() {
         try {
             return BetaAccessSignUpMapper.toDTOList(repository.findAll());
@@ -94,6 +97,7 @@ public class BetaAccessSignUpService implements IBetaAccessSignUpService {
      * @return The updated beta access sign up DTO
      */
     @Override
+    @CacheEvict(value = "betaAccessRecords", allEntries = true)
     public BetaAccessSignUpDTO updateEmailedStatus(UUID id, Boolean hasBeenEmailed) {
         try {
             BetaAccessSignUp entity = repository.findById(id)

--- a/src/main/java/com/danielagapov/spawn/Services/BlockedUser/BlockedUserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/BlockedUser/BlockedUserService.java
@@ -10,6 +10,8 @@ import com.danielagapov.spawn.Models.User;
 import com.danielagapov.spawn.Repositories.IBlockedUserRepository;
 import com.danielagapov.spawn.Services.FriendTag.IFriendTagService;
 import com.danielagapov.spawn.Services.User.IUserService;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import com.danielagapov.spawn.DTOs.BlockedUser.BlockedUserDTO;
@@ -34,6 +36,7 @@ public class BlockedUserService implements IBlockedUserService {
     }
 
     @Override
+    @CacheEvict(value = {"blockedUsers", "blockedUserIds"}, key = "#blockerId")
     public void blockUser(UUID blockerId, UUID blockedId, String reason) {
         if (blockerId.equals(blockedId)) return;
 
@@ -66,6 +69,7 @@ public class BlockedUserService implements IBlockedUserService {
     }
 
     @Override
+    @CacheEvict(value = {"blockedUsers", "blockedUserIds"}, key = "#blockerId")
     public void unblockUser(UUID blockerId, UUID blockedId) {
         try {
             repository.findByBlocker_IdAndBlocked_Id(blockerId, blockedId)
@@ -80,6 +84,7 @@ public class BlockedUserService implements IBlockedUserService {
     }
 
     @Override
+    @Cacheable(value = "isBlocked", key = "#blockerId.toString() + ':' + #blockedId.toString()")
     public boolean isBlocked(UUID blockerId, UUID blockedId) {
         try {
             return repository.existsByBlocker_IdAndBlocked_Id(blockerId, blockedId);
@@ -93,6 +98,7 @@ public class BlockedUserService implements IBlockedUserService {
     }
 
     @Override
+    @Cacheable(value = "blockedUsers", key = "#blockerId")
     public List<BlockedUserDTO> getBlockedUsers(UUID blockerId) {
         try {
             return repository.findAllByBlocker_Id(blockerId).stream()
@@ -105,6 +111,7 @@ public class BlockedUserService implements IBlockedUserService {
     }
 
     @Override
+    @Cacheable(value = "blockedUserIds", key = "#blockerId")
     public List<UUID> getBlockedUserIds(UUID blockerId) {
         try {
             return repository.findAllByBlocker_Id(blockerId).stream()

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -115,7 +115,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public FriendTagDTO saveFriendTag(AbstractFriendTagDTO friendTag) {
         FriendTag friendTagEntity = FriendTagMapper.toEntity(friendTag);
         friendTagEntity = saveFriendTagEntity(friendTagEntity);
@@ -135,7 +135,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public FriendTagDTO replaceFriendTag(FriendTagDTO newFriendTag, UUID id) {
         return repository.findById(id).map(friendTag -> {
             friendTag.setColorHexCode(newFriendTag.getColorHexCode());
@@ -150,7 +150,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public boolean deleteFriendTagById(UUID id) {
         if (!repository.existsById(id)) {
             throw new BaseNotFoundException(EntityType.FriendTag, id);
@@ -177,7 +177,7 @@ public class FriendTagService implements IFriendTagService {
 
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public void saveUserToFriendTag(UUID id, UUID userId) {
         if (!repository.existsById(id)) {
             throw new BaseNotFoundException(EntityType.FriendTag, id);
@@ -212,7 +212,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public void removeUserFromFriendTag(UUID id, UUID userId) {
         // Check if the FriendTag exists
         if (!repository.existsById(id)) {
@@ -243,7 +243,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
-    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
+    @CacheEvict(value = "eventsByFriendTagId", key = "#id")
     public void bulkAddUsersToFriendTag(UUID friendTagId, List<BaseUserDTO> friends) {
         for (BaseUserDTO friend : friends) {
             saveUserToFriendTag(friendTagId, friend.getId());

--- a/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendTag/FriendTagService.java
@@ -18,6 +18,7 @@ import com.danielagapov.spawn.Repositories.IUserFriendTagRepository;
 import com.danielagapov.spawn.Repositories.IUserRepository;
 import com.danielagapov.spawn.Services.User.IUserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 
@@ -114,6 +115,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public FriendTagDTO saveFriendTag(AbstractFriendTagDTO friendTag) {
         FriendTag friendTagEntity = FriendTagMapper.toEntity(friendTag);
         friendTagEntity = saveFriendTagEntity(friendTagEntity);
@@ -133,6 +135,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public FriendTagDTO replaceFriendTag(FriendTagDTO newFriendTag, UUID id) {
         return repository.findById(id).map(friendTag -> {
             friendTag.setColorHexCode(newFriendTag.getColorHexCode());
@@ -147,6 +150,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public boolean deleteFriendTagById(UUID id) {
         if (!repository.existsById(id)) {
             throw new BaseNotFoundException(EntityType.FriendTag, id);
@@ -173,6 +177,7 @@ public class FriendTagService implements IFriendTagService {
 
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public void saveUserToFriendTag(UUID id, UUID userId) {
         if (!repository.existsById(id)) {
             throw new BaseNotFoundException(EntityType.FriendTag, id);
@@ -207,6 +212,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public void removeUserFromFriendTag(UUID id, UUID userId) {
         // Check if the FriendTag exists
         if (!repository.existsById(id)) {
@@ -237,6 +243,7 @@ public class FriendTagService implements IFriendTagService {
     }
 
     @Override
+    @CacheEvict(value = "eventsByFriendTagId", key = "#friendTagId")
     public void bulkAddUsersToFriendTag(UUID friendTagId, List<BaseUserDTO> friends) {
         for (BaseUserDTO friend : friends) {
             saveUserToFriendTag(friendTagId, friend.getId());

--- a/src/main/java/com/danielagapov/spawn/SpawnApplication.java
+++ b/src/main/java/com/danielagapov/spawn/SpawnApplication.java
@@ -3,12 +3,14 @@ package com.danielagapov.spawn;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaRepositories
 @EnableScheduling
+@EnableCaching
 public class SpawnApplication {
     public static void main(String[] args) {
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,4 +18,10 @@ apns.certificate.path=${APNS_CERTIFICATE}
 apns.certificate.password=${CERTIFICATE_PASSWORD}
 apns.production=true
 
+# Redis Connection
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.password=${REDIS_PASSWORD}
+spring.cache.type=redis
+
 # Firebase Configuration for Android


### PR DESCRIPTION
### Summary
Integrated Redis caching into `EventService` methods to improve performance and reduce database load.

### Key Changes
- **Added `@Cacheable`** to:
  - `getEventById`, `getFullEventById`
  - `getEventsByOwnerId`, `getEventsByFriendTagId`
  - `getEventsInvitedTo`, `getFullEventsInvitedTo`
  - `getFeedEvents`, `getFilteredFeedEventsByFriendTagId`
  
- **Added `@CacheEvict`** to:
  - `saveEvent`, `createEvent`, `replaceEvent`, `deleteEventById`
  - `inviteUser`, `toggleParticipation`
  - `save/replace/deleteFriendTag`
  - `save/removeUserTo/fromFriendTag`

- **Redis Config**:
  - Set `REDIS_HOST`, `REDIS_PORT`, `REDIS_PASSWORD` as environment variables (shared only with backend)
  - Setup Redis on railway

- **TODO**:
  - Finish implementing cache evicts on methods that affect eventservice (like chatmessages)
  - Add caching to other service classes
  - Future: consider TTLs or cache grouping for optimization
