### PR TITLE
FCM Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
             <artifactId>spring-boot-starter-data-redis</artifactId>
             <version>3.2.5</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.firebase</groupId>
+            <artifactId>firebase-admin</artifactId>
+            <version>9.4.1</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
+++ b/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
@@ -12,9 +12,15 @@ import java.io.IOException;
 
 @Configuration
 public class FCMInitializer {
+    private final ILogger logger;
+
+    public FCMInitializer(ILogger logger) {
+        this.logger = logger;
+    }
+
 
     @PostConstruct
-    public void initialize(ILogger logger) {
+    public void initialize() {
         try {
             String credentials = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
             FirebaseOptions options = FirebaseOptions.builder()

--- a/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
+++ b/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
@@ -1,0 +1,29 @@
+package com.danielagapov.spawn.Config;
+
+import com.danielagapov.spawn.Exceptions.Logger.ILogger;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.IOException;
+
+@Configuration
+public class FCMInitializer {
+
+    @PostConstruct
+    public void initialize(ILogger logger) {
+        try {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.getApplicationDefault())
+                    .build();
+            if (FirebaseApp.getApps().isEmpty()) {
+                FirebaseApp.initializeApp(options);
+                logger.info("Firebase application initialized");
+            }
+        } catch (IOException e) {
+            logger.error("Error initializing Firebase: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
+++ b/src/main/java/com/danielagapov/spawn/Config/FCMInitializer.java
@@ -7,6 +7,7 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 @Configuration
@@ -15,8 +16,9 @@ public class FCMInitializer {
     @PostConstruct
     public void initialize(ILogger logger) {
         try {
+            String credentials = System.getenv("GOOGLE_APPLICATION_CREDENTIALS");
             FirebaseOptions options = FirebaseOptions.builder()
-                    .setCredentials(GoogleCredentials.getApplicationDefault())
+                    .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(credentials.getBytes())))
                     .build();
             if (FirebaseApp.getApps().isEmpty()) {
                 FirebaseApp.initializeApp(options);

--- a/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
@@ -20,10 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-
-import java.util.Arrays;
-import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -36,29 +32,29 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .cors(cors -> cors.configurationSource(request -> {
-                    CorsConfiguration configuration = new CorsConfiguration();
-                    configuration.setAllowedOrigins(List.of(
-                            "https://getspawn.com",
-                            "https://admin.getspawn.com",
-                            "http://localhost:3000",
-                            "http://localhost:8080",
-                            "http://localhost:4200",
-                            "http://localhost:8100", // ionic default
-                            "http://127.0.0.1:3000",
-                            "http://127.0.0.1:8080",
-                            "capacitor://localhost"
-                    ));
-
-                    // DEBUG: Log the origin to identify what the iOS simulator is sending
-                    String origin = request.getHeader("Origin");
-                    System.out.println("Incoming request origin: " + origin);
-                    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-                    configuration.setAllowedHeaders(List.of("Authorization", "X-Refresh-Token", "Content-Type", "Accept"));
-                    configuration.setExposedHeaders(List.of("Authorization", "X-Refresh-Token"));
-                    configuration.setAllowCredentials(true);
-                    return configuration;
-                }))
+//                .cors(cors -> cors.configurationSource(request -> {
+//                    CorsConfiguration configuration = new CorsConfiguration();
+//                    configuration.setAllowedOrigins(List.of(
+//                            "https://getspawn.com",
+//                            "https://admin.getspawn.com",
+//                            "http://localhost:3000",
+//                            "http://localhost:8080",
+//                            "http://localhost:4200",
+//                            "http://localhost:8100", // ionic default
+//                            "http://127.0.0.1:3000",
+//                            "http://127.0.0.1:8080",
+//                            "capacitor://localhost"
+//                    ));
+//
+//                    // DEBUG: Log the origin to identify what the iOS simulator is sending
+//                    String origin = request.getHeader("Origin");
+//                    System.out.println("Incoming request origin: " + origin);
+//                    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+//                    configuration.setAllowedHeaders(List.of("Authorization", "X-Refresh-Token", "Content-Type", "Accept"));
+//                    configuration.setExposedHeaders(List.of("Authorization", "X-Refresh-Token"));
+//                    configuration.setAllowCredentials(true);
+//                    return configuration;
+//                }))
                 .csrf(AbstractHttpConfigurer::disable)
                 // Endpoints can be made unsecured by specifying it with requestMatchers() below and permitting
                 // that be accessed without authentication with permitAll().

--- a/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
@@ -20,6 +20,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+
+import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @EnableWebSecurity
@@ -32,37 +36,37 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-//                .cors(cors -> cors.configurationSource(request -> {
-//                    CorsConfiguration configuration = new CorsConfiguration();
-//                    configuration.setAllowedOrigins(List.of(
-//                            "https://getspawn.com",
-//                            "https://admin.getspawn.com",
-//                            "http://localhost:3000",
-//                            "http://localhost:8080",
-//                            "http://localhost:4200",
-//                            "http://localhost:8100", // ionic default
-//                            "http://127.0.0.1:3000",
-//                            "http://127.0.0.1:8080",
-//                            "capacitor://localhost"
-//                    ));
-//
-//                    // DEBUG: Log the origin to identify what the iOS simulator is sending
-//                    String origin = request.getHeader("Origin");
-//                    System.out.println("Incoming request origin: " + origin);
-//                    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
-//                    configuration.setAllowedHeaders(List.of("Authorization", "X-Refresh-Token", "Content-Type", "Accept"));
-//                    configuration.setExposedHeaders(List.of("Authorization", "X-Refresh-Token"));
-//                    configuration.setAllowCredentials(true);
-//                    return configuration;
-//                }))
+                .cors(cors -> cors.configurationSource(request -> {
+                    CorsConfiguration configuration = new CorsConfiguration();
+                    configuration.setAllowedOrigins(List.of(
+                            "https://getspawn.com",
+                            "https://admin.getspawn.com",
+                            "http://localhost:3000",
+                            "http://localhost:8080",
+                            "http://localhost:4200",
+                            "http://localhost:8100", // ionic default
+                            "http://127.0.0.1:3000",
+                            "http://127.0.0.1:8080",
+                            "capacitor://localhost"
+                    ));
+
+                    // DEBUG: Log the origin to identify what the iOS simulator is sending
+                    String origin = request.getHeader("Origin");
+                    System.out.println("Incoming request origin: " + origin);
+                    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+                    configuration.setAllowedHeaders(List.of("Authorization", "X-Refresh-Token", "Content-Type", "Accept"));
+                    configuration.setExposedHeaders(List.of("Authorization", "X-Refresh-Token"));
+                    configuration.setAllowCredentials(true);
+                    return configuration;
+                }))
                 .csrf(AbstractHttpConfigurer::disable)
                 // Endpoints can be made unsecured by specifying it with requestMatchers() below and permitting
                 // that be accessed without authentication with permitAll().
                 // Below, the auth and oauth endpoints are unsecured
                 .authorizeHttpRequests(authorize -> authorize
-                                .requestMatchers("/api/v1/auth/**", "/api/v1/notifications/notification").permitAll()
-                        //.anyRequest()
-                        //.authenticated() // Comment this out if wanting to unsecure endpoints for development purposes
+                        .requestMatchers("/api/v1/auth/**", "/api/v1/notifications/notification").permitAll()
+                        .anyRequest()
+                        .authenticated() // Comment this out if wanting to unsecure endpoints for development purposes
                 )
                 // When authenticating a request fails, status code 401 (unauthorized) is returned
                 .exceptionHandling(e -> e

--- a/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
@@ -64,9 +64,9 @@ public class SecurityConfig {
                 // that be accessed without authentication with permitAll().
                 // Below, the auth and oauth endpoints are unsecured
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/v1/auth/**", "/api/v1/notifications/notification").permitAll()
-                        .anyRequest()
-                        .authenticated() // Comment this out if wanting to unsecure endpoints for development purposes
+                                .requestMatchers("/api/v1/auth/**", "/api/v1/notifications/notification").permitAll()
+                        //.anyRequest()
+                        //.authenticated() // Comment this out if wanting to unsecure endpoints for development purposes
                 )
                 // When authenticating a request fails, status code 401 (unauthorized) is returned
                 .exceptionHandling(e -> e

--- a/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/SecurityConfig.java
@@ -39,8 +39,8 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(request -> {
                     CorsConfiguration configuration = new CorsConfiguration();
                     configuration.setAllowedOrigins(List.of(
-                            "https://getspawn.com", 
-                            "https://admin.getspawn.com", 
+                            "https://getspawn.com",
+                            "https://admin.getspawn.com",
                             "http://localhost:3000",
                             "http://localhost:8080",
                             "http://localhost:4200",
@@ -64,7 +64,7 @@ public class SecurityConfig {
                 // that be accessed without authentication with permitAll().
                 // Below, the auth and oauth endpoints are unsecured
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/**", "/api/v1/notifications/notification").permitAll()
                         .anyRequest()
                         .authenticated() // Comment this out if wanting to unsecure endpoints for development purposes
                 )

--- a/src/main/java/com/danielagapov/spawn/Controllers/NotificationController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/NotificationController.java
@@ -4,6 +4,7 @@ import com.danielagapov.spawn.DTOs.DeviceTokenDTO;
 import com.danielagapov.spawn.DTOs.Notification.NotificationPreferencesDTO;
 import com.danielagapov.spawn.Services.PushNotification.FCMService;
 import com.danielagapov.spawn.Services.PushNotification.NotificationService;
+import com.danielagapov.spawn.Services.PushNotification.NotificationVO;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -81,10 +82,11 @@ public class NotificationController {
     }
 
     // full path: /api/v1/notifications
+    @Deprecated(since = "for testing purposes")
     @GetMapping("/notification")
     public ResponseEntity<?> testNotification(@RequestParam String deviceToken) {
         try {
-            fcmService.sendMessageToToken(deviceToken, "Test", "This is a test notification sent from Spawn Backend", null);
+            fcmService.sendMessageToToken(new NotificationVO(deviceToken, "Test", "This is a test notification sent from Spawn Backend", null));
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/danielagapov/spawn/Controllers/NotificationController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/NotificationController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.UUID;
 
 @RestController
@@ -86,7 +87,7 @@ public class NotificationController {
     @GetMapping("/notification")
     public ResponseEntity<?> testNotification(@RequestParam String deviceToken) {
         try {
-            fcmService.sendMessageToToken(new NotificationVO(deviceToken, "Test", "This is a test notification sent from Spawn Backend", null));
+            fcmService.sendMessageToToken(new NotificationVO(deviceToken, "Test", "This is a test notification sent from Spawn Backend", new HashMap<>()));
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/com/danielagapov/spawn/Services/PushNotification/FCMService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/PushNotification/FCMService.java
@@ -19,6 +19,13 @@ public class FCMService {
         this.logger = logger;
     }
 
+    /**
+     * Sends a push notification to a specific device using its FCM token.
+     *
+     * @param notification the notification payload including title, message, device token, and custom data
+     * @throws InterruptedException if the async FCM call is interrupted
+     * @throws ExecutionException   if the FCM send fails
+     */
     public void sendMessageToToken(NotificationVO notification)
             throws InterruptedException, ExecutionException {
         Message messageToSend = getPreconfiguredMessageToToken(notification);
@@ -28,17 +35,37 @@ public class FCMService {
         logger.info("Sent message to token. Device token: " + notification.getDeviceToken() + ", " + response + " msg " + jsonOutput);
     }
 
+
+    /**
+     * Sends the message asynchronously using FirebaseMessaging and returns the message ID.
+     *
+     * @param message the FCM message to send
+     * @return the message ID returned by FCM
+     */
     private String sendAndGetResponse(Message message) throws InterruptedException, ExecutionException {
         return FirebaseMessaging.getInstance().sendAsync(message).get();
     }
 
+    /**
+     * Builds the APNs (Apple Push Notification Service) configuration for iOS devices.
+     *
+     * @param topic the iOS topic, usually the app bundle ID
+     * @return the APNs configuration
+     */
     private ApnsConfig getApnsConfig(String topic) {
         return ApnsConfig.builder()
                 .setAps(Aps.builder().setCategory(topic).setThreadId(topic).build()).build();
     }
 
+
+    /**
+     * Builds the Android-specific notification configuration.
+     *
+     * @param topic a tag or category to associate with the Android notification
+     * @return the Android configuration
+     */
     private AndroidConfig getAndroidConfig(String topic) {
-        // To fully implement later
+        // To fully implement later -- e.g. extending this with priority, TTL, sound, etc., as needed
         return AndroidConfig.builder()
                 .setNotification(
                         AndroidNotification.builder()
@@ -47,6 +74,13 @@ public class FCMService {
                 .build();
     }
 
+
+    /**
+     * Builds the complete FCM message targeting a single device, including data and platform-specific settings.
+     *
+     * @param notification the notification value object
+     * @return a fully built FCM Message object
+     */
     private Message getPreconfiguredMessageToToken(NotificationVO notification) {
         return getPreconfiguredMessageBuilder(notification)
                 .setToken(notification.getDeviceToken())
@@ -54,6 +88,13 @@ public class FCMService {
                 .build();
     }
 
+    /**
+     * Constructs the base message builder with title, body, and platform configs (iOS and Android).
+     * FCM automatically applies the correct config based on the device token's platform.
+     *
+     * @param notificationVO the notification payload
+     * @return a preconfigured Message.Builder
+     */
     private Message.Builder getPreconfiguredMessageBuilder(NotificationVO notificationVO) {
         ApnsConfig apnsConfig = getApnsConfig(appBundleId);
         AndroidConfig androidConfig = getAndroidConfig("android");

--- a/src/main/java/com/danielagapov/spawn/Services/PushNotification/FCMService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/PushNotification/FCMService.java
@@ -1,0 +1,55 @@
+package com.danielagapov.spawn.Services.PushNotification;
+
+import com.danielagapov.spawn.Exceptions.Logger.ILogger;
+import com.google.firebase.messaging.*;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+@Service
+public class FCMService {
+    private ILogger logger;
+    @Value("${apns.bundle.id}")
+    private String appBundleId;
+
+    public FCMService(ILogger logger) {
+        this.logger = logger;
+    }
+
+    public void sendMessageToToken(String deviceToken, String title, String message, Map<String, String> data)
+            throws InterruptedException, ExecutionException {
+        Message messageToSend = getPreconfiguredMessageToToken(deviceToken, title, message, data);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        String jsonOutput = gson.toJson(messageToSend);
+        String response = sendAndGetResponse(messageToSend);
+        logger.info("Sent message to token. Device token: " + deviceToken + ", " + response + " msg " + jsonOutput);
+    }
+
+    private String sendAndGetResponse(Message message) throws InterruptedException, ExecutionException {
+        return FirebaseMessaging.getInstance().sendAsync(message).get();
+    }
+
+    private ApnsConfig getApnsConfig(String topic) {
+        return ApnsConfig.builder()
+                .setAps(Aps.builder().setCategory(topic).setThreadId(topic).build()).build();
+    }
+
+    private Message getPreconfiguredMessageToToken(String deviceToken, String title, String message, Map<String, String> data) {
+        return getPreconfiguredMessageBuilder(deviceToken, title, message, data).setToken(deviceToken)
+                .build();
+    }
+
+    private Message.Builder getPreconfiguredMessageBuilder(String deviceToken, String title, String message, Map<String, String> data) {
+        ApnsConfig apnsConfig = getApnsConfig(appBundleId);
+        Notification notification = Notification.builder()
+                .setTitle(title)
+                .setBody(message)
+                .build();
+        return Message.builder()
+                .setApnsConfig(apnsConfig).setNotification(notification);
+    }
+}

--- a/src/main/java/com/danielagapov/spawn/Services/PushNotification/NotificationVO.java
+++ b/src/main/java/com/danielagapov/spawn/Services/PushNotification/NotificationVO.java
@@ -1,0 +1,15 @@
+package com.danielagapov.spawn.Services.PushNotification;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class NotificationVO {
+    private String deviceToken;
+    private String title;
+    private String message;
+    private Map<String, String> data;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,11 +18,9 @@ apns.certificate.path=${APNS_CERTIFICATE}
 apns.certificate.password=${CERTIFICATE_PASSWORD}
 apns.production=true
 apns.bundle.id=${APNS_BUNDLE_ID}
-
 # Redis Connection
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
 spring.cache.type=redis
-
 # Firebase Configuration for Android


### PR DESCRIPTION
Backend FCM integration.

The new `FCMService` class is used solely for sending a notification to the device (technically to the remote FCM service, then the device). FCM handles whether the notification should be sent to an iOS or an Android device, so we no longer need the `APNStrategy` and `AndroidStrategy` classes since our backend can treat sending a notification the same, regardless of the user's actual device type. This will be removed in a future PR once it is completely confirmed that notifications are working correctly.