### PR TITLE
Recently Spawned With Users

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
@@ -1,10 +1,7 @@
 package com.danielagapov.spawn.Controllers.User;
 
-import com.danielagapov.spawn.DTOs.User.AbstractUserDTO;
-import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
+import com.danielagapov.spawn.DTOs.User.*;
 import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
-import com.danielagapov.spawn.DTOs.User.UserDTO;
-import com.danielagapov.spawn.DTOs.User.UserUpdateDTO;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Logger.ILogger;
 import com.danielagapov.spawn.Services.S3.IS3Service;
@@ -49,7 +46,7 @@ public class UserController {
     @GetMapping("{id}")
     public ResponseEntity<BaseUserDTO> getUser(@PathVariable UUID id) {
         if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        try { 
+        try {
             return new ResponseEntity<>(userService.getBaseUserById(id), HttpStatus.OK);
         } catch (BaseNotFoundException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
@@ -168,7 +165,7 @@ public class UserController {
 
     // full path: /api/v1/users/{userId}/recent-users
     @GetMapping("{userId}/recent-users")
-    public ResponseEntity<List<BaseUserDTO>> getRecentlySpawnedWithUsers(@PathVariable UUID userId) {
+    public ResponseEntity<List<RecentlySpawnedUserDTO>> getRecentlySpawnedWithUsers(@PathVariable UUID userId) {
         try {
             return new ResponseEntity<>(userService.getRecentlySpawnedWithUsers(userId), HttpStatus.OK);
         } catch (Exception e) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
@@ -171,4 +171,14 @@ public class UserController {
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
         }
     }
+
+    // full path: /api/v1/users/{userId}/recent-users
+    @GetMapping("{userId}/recent-users")
+    public ResponseEntity<List<BaseUserDTO>> getRecentlySpawnedWithUsers(@PathVariable UUID userId) {
+        try {
+            return new ResponseEntity<>(userService.getRecentlySpawnedWithUsers(userId), HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/DTOs/User/AbstractUserDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/User/AbstractUserDTO.java
@@ -2,6 +2,7 @@ package com.danielagapov.spawn.DTOs.User;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.io.Serializable;
@@ -10,6 +11,7 @@ import java.util.UUID;
 @AllArgsConstructor
 @Getter
 @Setter
+@NoArgsConstructor
 // Abstract class since interface describes behaviours
 public abstract class AbstractUserDTO implements Serializable {
     private UUID id;

--- a/src/main/java/com/danielagapov/spawn/DTOs/User/BaseUserDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/User/BaseUserDTO.java
@@ -1,12 +1,14 @@
 package com.danielagapov.spawn.DTOs.User;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.UUID;
 
 @Getter
 @Setter
+@NoArgsConstructor
 public class BaseUserDTO extends AbstractUserDTO {
     private String profilePicture;
 

--- a/src/main/java/com/danielagapov/spawn/DTOs/User/RecentlySpawnedUserDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/User/RecentlySpawnedUserDTO.java
@@ -1,0 +1,13 @@
+package com.danielagapov.spawn.DTOs.User;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+
+@AllArgsConstructor
+@Getter
+public class RecentlySpawnedUserDTO {
+    private BaseUserDTO user;
+    private OffsetDateTime dateTime;
+}

--- a/src/main/java/com/danielagapov/spawn/DTOs/UserIdEventTimeDTO.java
+++ b/src/main/java/com/danielagapov/spawn/DTOs/UserIdEventTimeDTO.java
@@ -1,0 +1,14 @@
+package com.danielagapov.spawn.DTOs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@AllArgsConstructor
+@Getter
+public class UserIdEventTimeDTO {
+    private UUID userId;
+    private OffsetDateTime startTime;
+}

--- a/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
@@ -1,5 +1,6 @@
 package com.danielagapov.spawn.Repositories;
 
+import com.danielagapov.spawn.DTOs.UserIdEventTimeDTO;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
 import com.danielagapov.spawn.Models.CompositeKeys.EventUsersId;
 import com.danielagapov.spawn.Models.EventUser;
@@ -28,8 +29,8 @@ public interface IEventUserRepository extends JpaRepository<EventUser, EventUser
     @Query("SELECT eu.event.id FROM EventUser eu WHERE eu.user.id = :userId AND eu.status = :status AND eu.event.endTime <= current_time")
     List<UUID> findPastEventIdsForUser(UUID userId, ParticipationStatus status, Limit limit);
 
-    @Query("SELECT DISTINCT eu.user.id FROM EventUser eu WHERE eu.event.id IN :eventIds AND eu.status = :status AND eu.user.id != :userId GROUP BY eu.user.id ORDER BY MAX(eu.event.startTime) DESC")
-    List<UUID> findOtherUserIdsByEventIds(List<UUID> eventIds, UUID userId, ParticipationStatus status);
+    @Query("SELECT DISTINCT new com.danielagapov.spawn.DTOs.UserIdEventTimeDTO(eu.user.id, eu.event.startTime) FROM EventUser eu WHERE eu.event.id IN :eventIds AND eu.status = :status AND eu.user.id != :userId GROUP BY eu.user.id ORDER BY MAX(eu.event.startTime) DESC")
+    List<UserIdEventTimeDTO> findOtherUserIdsByEventIds(List<UUID> eventIds, UUID userId, ParticipationStatus status);
 
     Optional<EventUser> findByEvent_IdAndUser_Id(UUID eventId, UUID userId);
 

--- a/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IEventUserRepository.java
@@ -25,16 +25,6 @@ public interface IEventUserRepository extends JpaRepository<EventUser, EventUser
 
     List<EventUser> findEventsByEvent_IdAndStatus(UUID eventId, ParticipationStatus status);
 
-//    @Query("SELECT eu.user FROM EventUser eu " +
-//            "WHERE eu.user.id != :userId " +
-//            "AND eu.status = :status " +
-//            "AND eu.event.endTime <= current_time " +
-//            "AND eu.user.id NOT IN " +
-//            "(SELECT uf.friend.id FROM UserFriendTag uf JOIN FriendTag f WHERE f.ownerId = :userId AND f.isEveryone = true) " +
-//            "AND eu.event.id IN (SELECT subeu.event.id FROM EventUser subeu WHERE subeu.user.id = :userId AND subeu.status = :status) " +
-//            "ORDER BY eu.event.startTime DESC")
-//    List<User> findUsersRecentlySpawnedWith(UUID userId, ParticipationStatus status);
-
     @Query("SELECT eu.event.id FROM EventUser eu WHERE eu.user.id = :userId AND eu.status = :status AND eu.event.endTime <= current_time")
     List<UUID> findPastEventIdsForUser(UUID userId, ParticipationStatus status, Limit limit);
 

--- a/src/main/java/com/danielagapov/spawn/Repositories/IUserFriendTagRepository.java
+++ b/src/main/java/com/danielagapov/spawn/Repositories/IUserFriendTagRepository.java
@@ -24,4 +24,7 @@ public interface IUserFriendTagRepository extends JpaRepository<UserFriendTag, U
     boolean existsByFriendTagIdAndFriendId(UUID friendTagId, UUID friendId);
 
     Instant findTopByFriendTag_OwnerIdOrderByLastUpdatedDesc(UUID ownerId);
+
+    @Query("SELECT uft.friend.id FROM UserFriendTag uft WHERE uft.friendTag.isEveryone = true AND uft.friendTag.ownerId = :ownerId")
+    List<UUID> findFriendIdsByUserId(UUID ownerId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
@@ -57,7 +57,7 @@ public interface IUserService {
 
     /**
      * Gets the timestamp of the latest profile update from any of the user's friends.
-     * 
+     *
      * @param userId The user ID to get the latest friend profile update for
      * @return The timestamp of the latest friend profile update, or null if none found
      */
@@ -99,4 +99,6 @@ public interface IUserService {
      * Get the User entity by email
      */
     User getUserByEmail(String email);
+
+    List<BaseUserDTO> getRecentlySpawnedWithUsers(UUID requestingUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
@@ -3,6 +3,7 @@ package com.danielagapov.spawn.Services.User;
 import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.FullFriendUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
+import com.danielagapov.spawn.DTOs.User.RecentlySpawnedUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
 import com.danielagapov.spawn.DTOs.User.UserUpdateDTO;
 import com.danielagapov.spawn.Models.FriendTag;
@@ -99,5 +100,5 @@ public interface IUserService {
      */
     User getUserByEmail(String email);
 
-    List<BaseUserDTO> getRecentlySpawnedWithUsers(UUID requestingUserId);
+    List<RecentlySpawnedUserDTO> getRecentlySpawnedWithUsers(UUID requestingUserId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -29,7 +29,6 @@ import com.danielagapov.spawn.Services.FriendRequest.IFriendRequestService;
 import com.danielagapov.spawn.Services.FriendTag.IFriendTagService;
 import com.danielagapov.spawn.Services.S3.IS3Service;
 import com.danielagapov.spawn.Services.UserSearch.IUserSearchService;
-import com.danielagapov.spawn.Services.UserSearch.UserSearchService;
 import com.danielagapov.spawn.Util.LoggingUtils;
 import com.danielagapov.spawn.Util.SearchedUserResult;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,7 +67,7 @@ public class UserService implements IUserService {
                        IFriendTagService friendTagService,
                        IFriendTagRepository friendTagRepository,
                        IS3Service s3Service, ILogger logger,
-                       UserSearchService userSearchService,
+                       IUserSearchService userSearchService,
                        CacheManager cacheManager,
                        IFriendRequestService friendRequestService) {
         this.repository = repository;

--- a/src/main/java/com/danielagapov/spawn/Services/UserSearch/IUserSearchService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/UserSearch/IUserSearchService.java
@@ -5,6 +5,7 @@ import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
 import com.danielagapov.spawn.Util.SearchedUserResult;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public interface IUserSearchService {
@@ -13,4 +14,6 @@ public interface IUserSearchService {
     List<RecommendedFriendUserDTO> getLimitedRecommendedFriendsForUserId(UUID userId);
 
     List<BaseUserDTO> searchByQuery(String searchQuery);
+
+    Set<UUID> getExcludedUserIds(UUID userId);
 }

--- a/src/main/java/com/danielagapov/spawn/Services/UserSearch/UserSearchService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/UserSearch/UserSearchService.java
@@ -12,6 +12,7 @@ import com.danielagapov.spawn.Mappers.FriendUserMapper;
 import com.danielagapov.spawn.Mappers.UserMapper;
 import com.danielagapov.spawn.Models.User.User;
 import com.danielagapov.spawn.Repositories.User.IUserRepository;
+import com.danielagapov.spawn.Services.BlockedUser.IBlockedUserService;
 import com.danielagapov.spawn.Services.FriendRequest.IFriendRequestService;
 import com.danielagapov.spawn.Services.User.IUserService;
 import com.danielagapov.spawn.Util.SearchedUserResult;
@@ -30,6 +31,7 @@ public class UserSearchService implements IUserSearchService {
     private final IFriendRequestService friendRequestService;
     private final IUserService userService;
     private final IUserRepository userRepository;
+    private final IBlockedUserService blockedUserService;
     private final ILogger logger;
 
 
@@ -201,7 +203,7 @@ public class UserSearchService implements IUserSearchService {
     }
 
     // Create a set of the requesting user's friends, users they've sent requests to, users they've received requests from, and self for quick lookup
-    private Set<UUID> getExcludedUserIds(UUID userId) {
+    public Set<UUID> getExcludedUserIds(UUID userId) {
         // Fetch the requesting user's friends
         List<UUID> requestingUserFriendIds = userService.getFriendUserIdsByUserId(userId);
 
@@ -222,6 +224,7 @@ public class UserSearchService implements IUserSearchService {
         excludedUserIds.addAll(sentFriendRequestReceiverUserIds);
         excludedUserIds.addAll(receivedFriendRequestSenderUserIds);
         excludedUserIds.add(userId); // Exclude self
+        excludedUserIds.addAll(blockedUserService.getBlockedUserIds(userId));
 
         return excludedUserIds;
     }

--- a/src/main/java/com/danielagapov/spawn/SpawnApplication.java
+++ b/src/main/java/com/danielagapov/spawn/SpawnApplication.java
@@ -40,6 +40,24 @@ public class SpawnApplication {
         } catch (NullPointerException e) {
             System.err.println("Error: EMAIL_PASS environment variable not set. Consider setting, or adding a .env file.");
         }
+        try {
+            System.setProperty("APNS_CERTIFICATE",
+                    System.getenv("APNS_CERTIFICATE") != null ? System.getenv("APNS_CERTIFICATE") : dotenv.get("APNS_CERTIFICATE"));
+        } catch (NullPointerException e) {
+            System.err.println("Error: APNS_CERTIFICATE environment variable not set. Consider setting, or adding a .env file.");
+        }
+        try {
+            System.setProperty("CERTIFICATE_PASSWORD",
+                    System.getenv("CERTIFICATE_PASSWORD") != null ? System.getenv("CERTIFICATE_PASSWORD") : dotenv.get("CERTIFICATE_PASSWORD"));
+        } catch (NullPointerException e) {
+            System.err.println("Error: CERTIFICATE_PASSWORD environment variable not set. Consider setting, or adding a .env file.");
+        }
+        try {
+            System.setProperty("APNS_BUNDLE_ID",
+                    System.getenv("APNS_BUNDLE_ID") != null ? System.getenv("APNS_BUNDLE_ID") : dotenv.get("APNS_BUNDLE_ID"));
+        } catch (NullPointerException e) {
+            System.err.println("Error: APNS_BUNDLE_ID environment variable not set. Consider setting, or adding a .env file.");
+        }
         SpringApplication.run(SpawnApplication.class, args);
     }
 }

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/UserSearchServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/UserSearchServiceTests.java
@@ -9,6 +9,7 @@ import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
 import com.danielagapov.spawn.Exceptions.Logger.ILogger;
 import com.danielagapov.spawn.Models.User.User;
 import com.danielagapov.spawn.Repositories.User.IUserRepository;
+import com.danielagapov.spawn.Services.BlockedUser.IBlockedUserService;
 import com.danielagapov.spawn.Services.FriendRequest.IFriendRequestService;
 import com.danielagapov.spawn.Services.User.IUserService;
 import com.danielagapov.spawn.Services.UserSearch.UserSearchService;
@@ -43,6 +44,9 @@ class UserSearchServiceTests {
 
     @Mock
     private ILogger logger;
+
+    @Mock
+    private IBlockedUserService blockedUserService;
 
     @InjectMocks
     private UserSearchService userSearchService; // Injected service to test

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
@@ -1,12 +1,15 @@
 package com.danielagapov.spawn.ServiceTests;
 
+import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
+import com.danielagapov.spawn.Enums.ParticipationStatus;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BaseSaveException;
 import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
 import com.danielagapov.spawn.Exceptions.Logger.ILogger;
 import com.danielagapov.spawn.Models.FriendTag;
 import com.danielagapov.spawn.Models.User.User;
+import com.danielagapov.spawn.Repositories.IEventUserRepository;
 import com.danielagapov.spawn.Repositories.IFriendTagRepository;
 import com.danielagapov.spawn.Repositories.IUserFriendTagRepository;
 import com.danielagapov.spawn.Repositories.User.IUserRepository;
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 import org.springframework.dao.DataAccessException;
 
 import java.util.*;
@@ -56,6 +60,10 @@ public class UserServiceTests {
     @Mock
     private IUserSearchService userSearchService;
 
+    @Mock
+    private IEventUserRepository eventUserRepository;
+
+    @Spy
     @InjectMocks
     private UserService userService;
 
@@ -202,13 +210,13 @@ public class UserServiceTests {
     void deleteUserById_ShouldLogException_WhenUnexpectedErrorOccurs() {
         UUID userId = UUID.randomUUID();
         User user = new User(userId, "JohnDoe123", "profile.jpg", "John", "Doe", null, "johndoe@anon.com");
-        
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         doNothing().when(s3Service).deleteObjectByURL(anyString());
         doThrow(new RuntimeException("Unexpected error")).when(userRepository).deleteById(userId);
 
         Exception exception = assertThrows(RuntimeException.class, () -> userService.deleteUserById(userId));
-        
+
         assertEquals("Unexpected error", exception.getMessage());
         verify(logger, times(1)).error(anyString());
     }
@@ -229,9 +237,9 @@ public class UserServiceTests {
     void deleteUserById_ShouldNotCallDelete_WhenUserDoesNotExist() {
         UUID userId = UUID.randomUUID();
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
-        
+
         BaseNotFoundException exception = assertThrows(BaseNotFoundException.class, () -> userService.deleteUserById(userId));
-        
+
         assertTrue(exception.getMessage().contains("User"));
         verify(userRepository, never()).deleteById(userId);
     }
@@ -305,21 +313,16 @@ public class UserServiceTests {
         UUID uniqueFriend2Id = UUID.randomUUID();
 
         // User1's friends: mutualFriend1, mutualFriend2, uniqueFriend1
-        when(friendTagRepository.findByOwnerId(user1Id))
-                .thenReturn(List.of(createEveryoneTag(user1Id)));
-        when(userFriendTagRepository.findFriendIdsByTagId(any()))
+        when(userFriendTagRepository.findFriendIdsByUserId(any()))
                 .thenReturn(List.of(mutualFriend1Id, mutualFriend2Id, uniqueFriend1Id))
                 .thenReturn(List.of(mutualFriend1Id, mutualFriend2Id, uniqueFriend2Id));
 
         // User2's friends: mutualFriend1, mutualFriend2, uniqueFriend2
-        when(friendTagRepository.findByOwnerId(user2Id))
-                .thenReturn(List.of(createEveryoneTag(user2Id)));
 
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(2, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, times(2)).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -343,8 +346,7 @@ public class UserServiceTests {
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(0, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, times(2)).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -367,8 +369,7 @@ public class UserServiceTests {
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(0, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, times(2)).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -385,8 +386,7 @@ public class UserServiceTests {
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(0, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, times(2)).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -401,8 +401,7 @@ public class UserServiceTests {
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(0, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, never()).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -416,8 +415,7 @@ public class UserServiceTests {
         int result = userService.getMutualFriendCount(user1Id, user2Id);
 
         assertEquals(0, result);
-        verify(friendTagRepository, times(2)).findByOwnerId(any());
-        verify(userFriendTagRepository, never()).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(2)).findFriendIdsByUserId(any());
     }
 
     @Test
@@ -467,12 +465,95 @@ public class UserServiceTests {
         List<UUID> result = userService.getFriendUserIdsByUserId(userId);
 
         assertTrue(result.isEmpty());
-        verify(friendTagRepository, times(1)).findByOwnerId(userId);
-        verify(userFriendTagRepository, never()).findFriendIdsByTagId(any());
+        verify(userFriendTagRepository, times(1)).findFriendIdsByUserId(any());
+    }
+
+    @Test
+    void testGetRecentlySpawnedWithUsers() {
+        // Setup mock data for the repository methods
+        UUID requestingUserId = UUID.randomUUID();
+        List<UUID> pastEventIds = Arrays.asList(UUID.randomUUID(), UUID.randomUUID());
+        UUID friendId1 = UUID.randomUUID();
+        UUID friendId2 = UUID.randomUUID();
+        UUID nonFriendId = UUID.randomUUID();
+        List<UUID> pastEventParticipantIds = Arrays.asList(friendId1, friendId2, nonFriendId);
+        List<UUID> friendIds = Arrays.asList(friendId1, friendId2);
+
+        // Mock the repository methods
+        when(eventUserRepository.findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any()))
+                .thenReturn(pastEventIds);
+        when(eventUserRepository.findOtherUserIdsByEventIds(eq(pastEventIds), eq(requestingUserId), eq(ParticipationStatus.participating)))
+                .thenReturn(pastEventParticipantIds);
+        when(userService.getFriendUserIdsByUserId(eq(requestingUserId)))
+                .thenReturn(friendIds);
+
+        // Mock the getBaseUserById method (if necessary, return a mocked BaseUserDTO)
+        BaseUserDTO mockBaseUserDTO = new BaseUserDTO();
+        mockBaseUserDTO.setId(UUID.randomUUID());
+        doReturn(mockBaseUserDTO).when(userService).getBaseUserById(nonFriendId);
+
+        // Call the method
+        List<BaseUserDTO> result = userService.getRecentlySpawnedWithUsers(requestingUserId);
+
+        // Verify repository method interactions
+        verify(eventUserRepository, times(1)).findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any());
+        verify(eventUserRepository, times(1)).findOtherUserIdsByEventIds(eq(pastEventIds), eq(requestingUserId), eq(ParticipationStatus.participating));
+        verify(userService, times(1)).getFriendUserIdsByUserId(eq(requestingUserId));
+        verify(userService, times(1)).getBaseUserById(any(UUID.class));
+
+        // Assert the results
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertTrue(result.stream().allMatch(user -> !friendIds.contains(user.getId())));
+    }
+
+    @Test
+    void testGetRecentlySpawnedWithUsers_NoParticipants() {
+        // Setup mock data for no participants
+        UUID requestingUserId = UUID.randomUUID();
+        List<UUID> pastEventIds = Collections.emptyList();
+        List<UUID> pastEventParticipantIds = Collections.emptyList();
+        List<UUID> friendIds = new ArrayList<>();
+
+        // Mock the repository methods
+        when(eventUserRepository.findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any()))
+                .thenReturn(pastEventIds);
+        when(eventUserRepository.findOtherUserIdsByEventIds(eq(pastEventIds), eq(requestingUserId), eq(ParticipationStatus.participating)))
+                .thenReturn(pastEventParticipantIds);
+        when(userService.getFriendUserIdsByUserId(eq(requestingUserId)))
+                .thenReturn(friendIds);
+
+        // Call the method
+        List<BaseUserDTO> result = userService.getRecentlySpawnedWithUsers(requestingUserId);
+
+        // Assert the results (should be an empty list)
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetRecentlySpawnedWithUsers_ExceptionHandling() {
+        // Simulate an exception being thrown in the repository method
+        UUID requestingUserId = UUID.randomUUID();
+        when(eventUserRepository.findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any()))
+                .thenThrow(new RuntimeException("Database error"));
+
+        // Call the method and assert it handles the exception
+        try {
+            userService.getRecentlySpawnedWithUsers(requestingUserId);
+            fail("Expected an exception to be thrown");
+        } catch (RuntimeException e) {
+            assertEquals("Database error", e.getMessage());
+        }
+
+        // Verify the repository interaction
+        verify(eventUserRepository, times(1)).findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any());
     }
 
     // Helper method to create an "Everyone" tag
     private FriendTag createEveryoneTag(UUID ownerId) {
         return new FriendTag(UUID.randomUUID(), "Everyone", "#000000", ownerId, true, null);
     }
+
+
 }

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
@@ -482,10 +482,12 @@ public class UserServiceTests {
         UUID friendId1 = UUID.randomUUID();
         UUID friendId2 = UUID.randomUUID();
         UUID nonFriendId = UUID.randomUUID();
+        UUID blockedId = UUID.randomUUID();
         UserIdEventTimeDTO friendIdEventTime1 = new UserIdEventTimeDTO(friendId1, OffsetDateTime.now());
         UserIdEventTimeDTO friendIdEventTime2 = new UserIdEventTimeDTO(friendId2, OffsetDateTime.now());
         UserIdEventTimeDTO nonfriendIdEventTime = new UserIdEventTimeDTO(nonFriendId, OffsetDateTime.now());
-        List<UserIdEventTimeDTO> pastEventParticipants = Arrays.asList(friendIdEventTime1, friendIdEventTime2, nonfriendIdEventTime);
+        UserIdEventTimeDTO blockedIdEventTime = new UserIdEventTimeDTO(blockedId, OffsetDateTime.now());
+        List<UserIdEventTimeDTO> pastEventParticipants = Arrays.asList(friendIdEventTime1, friendIdEventTime2, nonfriendIdEventTime, blockedIdEventTime);
         List<UUID> friendIds = Arrays.asList(friendId1, friendId2);
 
         // Mock the repository methods
@@ -495,6 +497,7 @@ public class UserServiceTests {
                 .thenReturn(pastEventParticipants);
         when(userService.getFriendUserIdsByUserId(eq(requestingUserId)))
                 .thenReturn(friendIds);
+        when(blockedUserService.getBlockedUserIds(requestingUserId)).thenReturn(List.of(blockedId));
 
         // Mock the getBaseUserById method (if necessary, return a mocked BaseUserDTO)
         BaseUserDTO mockBaseUserDTO = new BaseUserDTO();

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
@@ -214,7 +214,7 @@ public class UserServiceTests {
     void deleteUserById_ShouldLogException_WhenUnexpectedErrorOccurs() {
         UUID userId = UUID.randomUUID();
         User user = new User(userId, "JohnDoe123", "profile.jpg", "John Doe", null, "johndoe@anon.com");
-        
+
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         doNothing().when(s3Service).deleteObjectByURL(anyString());
         doThrow(new RuntimeException("Unexpected error")).when(userRepository).deleteById(userId);
@@ -493,9 +493,7 @@ public class UserServiceTests {
                 .thenReturn(pastEventIds);
         when(eventUserRepository.findOtherUserIdsByEventIds(eq(pastEventIds), eq(requestingUserId), eq(ParticipationStatus.participating)))
                 .thenReturn(pastEventParticipants);
-        when(userService.getFriendUserIdsByUserId(eq(requestingUserId)))
-                .thenReturn(friendIds);
-        when(blockedUserService.getBlockedUserIds(requestingUserId)).thenReturn(List.of(blockedId));
+        when(userSearchService.getExcludedUserIds(requestingUserId)).thenReturn(Set.of(blockedId, requestingUserId, friendId1, friendId2));
 
         // Mock the getBaseUserById method (if necessary, return a mocked BaseUserDTO)
         BaseUserDTO mockBaseUserDTO = new BaseUserDTO();
@@ -508,7 +506,6 @@ public class UserServiceTests {
         // Verify repository method interactions
         verify(eventUserRepository, times(1)).findPastEventIdsForUser(eq(requestingUserId), eq(ParticipationStatus.participating), any());
         verify(eventUserRepository, times(1)).findOtherUserIdsByEventIds(eq(pastEventIds), eq(requestingUserId), eq(ParticipationStatus.participating));
-        verify(userService, times(1)).getFriendUserIdsByUserId(eq(requestingUserId));
         verify(userService, times(1)).getBaseUserById(any(UUID.class));
 
         // Assert the results


### PR DESCRIPTION
Implementation for "recently spawned with users". The intended logic for this functionality involves fetching the recent events (currently capped at 10) a user has participated in and returning all other users who have also participated in any of those events and are not friends of the requesting user.

