### PR TITLE
Notify Team about Beta Sign Ups + Clean Logs

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Config/JWTFilterConfig.java
+++ b/src/main/java/com/danielagapov/spawn/Config/JWTFilterConfig.java
@@ -39,8 +39,6 @@ public class JWTFilterConfig extends OncePerRequestFilter {
                 filterChain.doFilter(request, response);
                 return;
             }
-            logger.info("Token found: " + authHeader);
-
             // Extract the JWT token from the Authorization header (removing the "Bearer " prefix)
             String jwt = authHeader.substring(7);
             String username;
@@ -60,8 +58,6 @@ public class JWTFilterConfig extends OncePerRequestFilter {
 
                     // Validate the JWT token against the UserDetails
                     if (jwtService.isValidToken(jwt, userDetails)) {
-                        logger.info("Token is valid, setting authentication");
-
                         /*
                          * Create an authentication token containing the user details and authorities.
                          * UsernamePasswordAuthenticationToken is a Spring Security authentication object

--- a/src/main/java/com/danielagapov/spawn/Controllers/User/AuthController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/User/AuthController.java
@@ -47,7 +47,6 @@ public class AuthController {
     @GetMapping("sign-in")
     public ResponseEntity<?> signIn(@RequestParam("externalUserId") String externalUserId, @RequestParam(value = "email", required = false) String email) {
         try {
-            logger.info(String.format("Received sign-in request: {externalUserId: %s, email: %s}", externalUserId, email));
             Optional<BaseUserDTO> optionalDTO = oauthService.getUserIfExistsbyExternalId(externalUserId, email);
             if (optionalDTO.isPresent()) {
                 BaseUserDTO baseUserDTO = optionalDTO.get();
@@ -81,8 +80,6 @@ public class AuthController {
                                                 @RequestParam("externalUserId") String externalUserId,
                                                 @RequestParam(value = "provider") OAuthProvider provider) {
         try {
-            logger.info(String.format("Received make-user request: {userDTO: %s, externalUserId: %s, provider: %s}",
-                    userCreationDTO, externalUserId, provider));
             BaseUserDTO user = oauthService.createUser(userCreationDTO, externalUserId, provider);
             HttpHeaders headers = makeHeadersForTokens(userCreationDTO.getUsername());
             return ResponseEntity.ok().headers(headers).body(user);
@@ -95,8 +92,6 @@ public class AuthController {
     @PostMapping("refresh-token")
     public ResponseEntity<String> refreshToken(HttpServletRequest request) {
         try {
-            logger.info(String.format("Refresh token request received: {token: %s}",
-                    request.getHeader("Authorization")));
             HttpHeaders headers = new HttpHeaders();
             String token = jwtService.refreshAccessToken(request);
             headers.add("Authorization", "Bearer " + token);
@@ -116,10 +111,8 @@ public class AuthController {
     @PostMapping("register")
     public ResponseEntity<UserDTO> register(@RequestBody() AuthUserDTO authUserDTO) {
         try {
-            logger.info(String.format("Account registration request received: {user: %s}", authUserDTO));
             UserDTO newUserDTO = authService.registerUser(authUserDTO);
             HttpHeaders headers = makeHeadersForTokens(newUserDTO.getUsername());
-            logger.info(String.format("User successfully registered: {user: %s}", newUserDTO));
             return ResponseEntity.ok().headers(headers).body(newUserDTO);
         } catch (FieldAlreadyExistsException fae) {
             logger.warn(fae.getMessage());
@@ -137,7 +130,6 @@ public class AuthController {
     @PostMapping("login")
     public ResponseEntity<BaseUserDTO> login(@RequestBody AuthUserDTO authUserDTO) {
         try {
-            logger.info(String.format("Login request received: {user: %s}", authUserDTO));
             BaseUserDTO existingUserDTO = authService.loginUser(authUserDTO);
             HttpHeaders headers = makeHeadersForTokens(existingUserDTO.getUsername());
             return ResponseEntity.ok().headers(headers).body(existingUserDTO);
@@ -165,13 +157,13 @@ public class AuthController {
             modelAndView.setStatus(HttpStatus.OK);
             return modelAndView;
         } catch (BaseNotFoundException e) {
-            logger.info("Error verifying email: " + e.getMessage() + ", entity type: " + e.entityType);
+            logger.error("Error verifying email: " + e.getMessage() + ", entity type: " + e.entityType);
             modelAndView.addObject("status", "not_found");
             modelAndView.addObject("entityType", e.entityType);
             modelAndView.setStatus(HttpStatus.NOT_FOUND);
             return modelAndView;
         } catch (Exception e) {
-            logger.info("Unexpected error while verifying email: " + e.getMessage());
+            logger.error("Unexpected error while verifying email: " + e.getMessage());
             modelAndView.addObject("status", "error");
             modelAndView.setStatus(HttpStatus.INTERNAL_SERVER_ERROR);
             return modelAndView;

--- a/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
@@ -90,9 +90,7 @@ public class UserController {
     public ResponseEntity<UserDTO> updatePfp(@PathVariable UUID id, @RequestBody byte[] file) {
         if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
-            logger.info("Received request to update profile picture for user " + id + " (file size: " + file.length + " bytes)");
             UserDTO updatedUser = s3Service.updateProfilePicture(file, id);
-            logger.info("Successfully updated profile picture for user " + id + ": " + updatedUser.getProfilePicture());
             return new ResponseEntity<>(updatedUser, HttpStatus.OK);
         } catch (Exception e) {
             logger.error("Error updating profile picture for user " + id + ": " + e.getMessage());
@@ -104,9 +102,7 @@ public class UserController {
     @GetMapping("default-pfp")
     public ResponseEntity<String> getDefaultProfilePicture() {
         try {
-            logger.info("Received request for default profile picture");
             String defaultPfp = s3Service.getDefaultProfilePicture();
-            logger.info("Returning default profile picture: " + defaultPfp);
             return new ResponseEntity<>(defaultPfp, HttpStatus.OK);
         } catch (Exception e) {
             logger.error("Error retrieving default profile picture: " + e.getMessage());

--- a/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/User/UserController.java
@@ -129,25 +129,10 @@ public class UserController {
     public ResponseEntity<BaseUserDTO> updateUser(@PathVariable UUID id, @RequestBody UserUpdateDTO updateDTO) {
         if (id == null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         try {
-            logger.info("Received request to update user " + id + ": " +
-                    "username=" + updateDTO.getUsername() + ", " +
-                    "firstName=" + updateDTO.getFirstName() + ", " +
-                    "lastName=" + updateDTO.getLastName() + ", " +
-                    "bio=" + updateDTO.getBio());
-
             BaseUserDTO updatedUser = userService.updateUser(
                     id,
-                    updateDTO.getBio(),
-                    updateDTO.getUsername(),
-                    updateDTO.getFirstName(),
-                    updateDTO.getLastName()
+                    updateDTO
             );
-
-            logger.info("Successfully updated user " + id + ": " +
-                    "username=" + updatedUser.getUsername() + ", " +
-                    "firstName=" + updatedUser.getFirstName() + ", " +
-                    "lastName=" + updatedUser.getLastName() + ", " +
-                    "bio=" + updatedUser.getBio());
 
             return new ResponseEntity<>(updatedUser, HttpStatus.OK);
         } catch (BaseNotFoundException e) {

--- a/src/main/java/com/danielagapov/spawn/Services/Auth/AuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/Auth/AuthService.java
@@ -54,7 +54,6 @@ public class AuthService implements IAuthService {
 
     @Override
     public BaseUserDTO loginUser(AuthUserDTO authUserDTO) {
-        logger.info("Attempting to login user: " + authUserDTO.getUsername());
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         authUserDTO.getUsername(),
@@ -63,10 +62,8 @@ public class AuthService implements IAuthService {
         );
         if (authentication.isAuthenticated()) {
             String username = ((UserDetails) authentication.getPrincipal()).getUsername();
-            logger.info("Authentication successful for user: " + username);
 
             User user = userService.getUserEntityByUsername(username);
-            logger.info("Login successful for user: " + LoggingUtils.formatUserInfo(user));
             return UserMapper.toDTO(user);
         } else {
             logger.warn("Failed authentication attempt for username: " + authUserDTO.getUsername());

--- a/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/IUserService.java
@@ -4,6 +4,7 @@ import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.FullFriendUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
+import com.danielagapov.spawn.DTOs.User.UserUpdateDTO;
 import com.danielagapov.spawn.Models.FriendTag;
 import com.danielagapov.spawn.Models.User.User;
 import com.danielagapov.spawn.Util.SearchedUserResult;
@@ -82,7 +83,7 @@ public interface IUserService {
 
     BaseUserDTO getBaseUserById(UUID id);
 
-    BaseUserDTO updateUser(UUID id, String bio, String username, String firstName, String lastName);
+    BaseUserDTO updateUser(UUID id, UserUpdateDTO updateUserDTO);
 
     SearchedUserResult getRecommendedFriendsBySearch(UUID requestingUserId, String searchQuery);
 

--- a/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/User/UserService.java
@@ -5,6 +5,7 @@ import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.FullFriendUserDTO;
 import com.danielagapov.spawn.DTOs.User.FriendUser.RecommendedFriendUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
+import com.danielagapov.spawn.DTOs.User.UserUpdateDTO;
 import com.danielagapov.spawn.Enums.EntityType;
 import com.danielagapov.spawn.Enums.ParticipationStatus;
 import com.danielagapov.spawn.Exceptions.ApplicationException;
@@ -497,15 +498,15 @@ public class UserService implements IUserService {
     }
 
     @Override
-    public BaseUserDTO updateUser(UUID id, String bio, String username, String firstName, String lastName) {
+    public BaseUserDTO updateUser(UUID id, UserUpdateDTO updateDTO) {
         try {
             User user = repository.findById(id)
                     .orElseThrow(() -> new BaseNotFoundException(EntityType.User, id));
 
-            user.setBio(bio);
-            user.setUsername(username);
-            user.setFirstName(firstName);
-            user.setLastName(lastName);
+            user.setBio(updateDTO.getBio());
+            user.setUsername(updateDTO.getUsername());
+            user.setFirstName(updateDTO.getFirstName());
+            user.setLastName(updateDTO.getLastName());
 
             user = repository.save(user);
 

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/BetaAccessSignUpServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/BetaAccessSignUpServiceTests.java
@@ -7,6 +7,7 @@ import com.danielagapov.spawn.Exceptions.Logger.ILogger;
 import com.danielagapov.spawn.Models.BetaAccessSignUp;
 import com.danielagapov.spawn.Repositories.IBetaAccessSignUpRepository;
 import com.danielagapov.spawn.Services.BetaAccessSignUp.BetaAccessSignUpService;
+import com.danielagapov.spawn.Services.Email.IEmailService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -27,6 +28,9 @@ public class BetaAccessSignUpServiceTests {
 
     @Mock
     private ILogger logger;
+
+    @Mock
+    private IEmailService emailService;
 
     @InjectMocks
     private BetaAccessSignUpService service;

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/UserServiceTests.java
@@ -2,6 +2,7 @@ package com.danielagapov.spawn.ServiceTests;
 
 import com.danielagapov.spawn.DTOs.User.BaseUserDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
+import com.danielagapov.spawn.DTOs.User.UserUpdateDTO;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.Base.BaseSaveException;
 import com.danielagapov.spawn.Exceptions.Base.BasesNotFoundException;
@@ -112,9 +113,10 @@ public class UserServiceTests {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(existingUser));
         when(userRepository.save(any(User.class))).thenReturn(updatedUser);
+        UserUpdateDTO updateDTO = new UserUpdateDTO("New bio", "new_username", "NewFirst", "NewLast");
 
         // Act
-        var result = userService.updateUser(userId, "New bio", "new_username", "NewFirst", "NewLast");
+        var result = userService.updateUser(userId, updateDTO);
 
         // Assert
         assertEquals("new_username", result.getUsername());
@@ -136,9 +138,10 @@ public class UserServiceTests {
         when(userRepository.findById(userId)).thenReturn(Optional.of(existingUser));
         when(userRepository.save(any(User.class))).thenReturn(updatedUser);
 
-        // Act - only updating bio and lastName, keeping other fields the same
-        var result = userService.updateUser(userId, "New bio", null, null, "NewLast");
+        UserUpdateDTO updateDTO = new UserUpdateDTO("New bio", "new_username", "NewFirst", "NewLast");
 
+        // Act
+        var result = userService.updateUser(userId, updateDTO);
         // Assert
         assertEquals("old_username", result.getUsername());  // unchanged
         assertEquals("OldFirst", result.getFirstName());     // unchanged
@@ -157,7 +160,7 @@ public class UserServiceTests {
 
         // Act & Assert
         BaseNotFoundException exception = assertThrows(BaseNotFoundException.class,
-                () -> userService.updateUser(userId, "New bio", "new_username", "NewFirst", "NewLast"));
+                () -> userService.updateUser(userId, new UserUpdateDTO("New bio", "new_username", "NewFirst", "NewLast")));
 
         assertTrue(exception.getMessage().contains("User"));
         verify(userRepository, times(1)).findById(userId);
@@ -176,7 +179,7 @@ public class UserServiceTests {
 
         // Act & Assert
         Exception exception = assertThrows(DataAccessException.class,
-                () -> userService.updateUser(userId, "New bio", "new_username", "NewFirst", "NewLast"));
+                () -> userService.updateUser(userId, new UserUpdateDTO("New bio", "new_username", "NewFirst", "NewLast")));
 
         assertTrue(exception.getMessage().contains("Database error"));
         verify(userRepository, times(1)).findById(userId);
@@ -279,7 +282,7 @@ public class UserServiceTests {
 
         // Act & Assert
         RuntimeException exception = assertThrows(RuntimeException.class,
-                () -> userService.updateUser(userId, "New bio", "new_username", "NewFirst", "NewLast"));
+                () -> userService.updateUser(userId, new UserUpdateDTO("New bio", "new_username", "NewFirst", "NewLast")));
 
         assertTrue(exception.getMessage().contains("Unexpected error"));
         verify(logger, times(1)).error(anyString());


### PR DESCRIPTION
- Kept logs for features in development or for ones that haven't been tested yet, like email/pass user registration, change password, etc.
    - Cleaned up ones that were clogging the Railway logs, though, like for tokens. 
- Notify team by email upon beta access sign up, since we haven't sent a follow-up invite since March but should, since new sign ups have been made
- Move logic of getting DTO properties from controller -> service layer for `UserService::updateUser()`

