### PR TITLE
Implement Sent Friend Req Domain + Fix Friend Req Deletion Bug (404)

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -56,6 +56,33 @@ public class FriendRequestController {
         }
     }
 
+    // returns ResponseEntity with list of FetchFriendRequestDTO (can be empty)
+    //  or not found entity type (user)
+    // full path: /api/v1/friend-requests/sent/{userId}
+    @GetMapping("sent/{userId}")
+    public ResponseEntity<?> getSentFriendRequestsByUserId(@PathVariable UUID userId) {
+        if (userId == null) {
+            logger.error("Invalid parameter: userId is null");
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        try {
+            return new ResponseEntity<>(friendRequestService.getSentFetchFriendRequestsByUserId(userId), HttpStatus.OK);
+        } catch (BaseNotFoundException e) {
+            logger.error("User not found for sent friend requests: " + LoggingUtils.formatUserIdInfo(userId) + ": " + e.getMessage());
+            return new ResponseEntity<>(e.entityType, HttpStatus.NOT_FOUND);
+        } catch (BasesNotFoundException e) {
+            if (e.entityType == EntityType.FriendRequest) {
+                return new ResponseEntity<>(new ArrayList<>(), HttpStatus.OK);
+            } else {
+                logger.error("Bad request for sent friend requests: " + e.getMessage());
+                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+            }
+        } catch (Exception e) {
+            logger.error("Error getting sent friend requests for user: " + LoggingUtils.formatUserIdInfo(userId) + ": " + e.getMessage());
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     // full path: /api/v1/friend-requests
     @PostMapping
     public ResponseEntity<CreateFriendRequestDTO> createFriendRequest(@RequestBody CreateFriendRequestDTO friendRequest) {

--- a/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
+++ b/src/main/java/com/danielagapov/spawn/Controllers/FriendRequestController.java
@@ -77,21 +77,27 @@ public class FriendRequestController {
             logger.error("Invalid parameter: friendRequestId is null");
             return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
         }
+        
+        logger.info("Processing friend request action: " + friendRequestAction + " for request ID: " + friendRequestId);
+        
         try {
             if (friendRequestAction == FriendRequestAction.accept) {
                 friendRequestService.acceptFriendRequest(friendRequestId);
+                logger.info("Successfully accepted friend request: " + friendRequestId);
             } else if (friendRequestAction == FriendRequestAction.reject) {
                 friendRequestService.deleteFriendRequest(friendRequestId);
+                logger.info("Successfully rejected friend request: " + friendRequestId);
             } else {
                 // deal with null/invalid argument for `friendRequestAction`
-                logger.error("Invalid friend request action: " + friendRequestAction);
+                logger.error("Invalid friend request action: " + friendRequestAction + " for request: " + friendRequestId);
                 return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
             }
 
             return new ResponseEntity<>(HttpStatus.OK);
         } catch (BaseNotFoundException e) {
-            logger.error("Friend request not found: " + friendRequestId + ": " + e.getMessage());
-            return new ResponseEntity<>(e.entityType, HttpStatus.NOT_FOUND);
+            logger.warn("Friend request not found (may have been already processed): " + friendRequestId + ": " + e.getMessage());
+            // Return success instead of 404 to avoid client-side errors when friend request was already processed
+            return new ResponseEntity<>(HttpStatus.OK);
         } catch (Exception e) {
             logger.error("Error processing friend request action: " + friendRequestAction + " for request: " + friendRequestId + ": " + e.getMessage());
             return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);

--- a/src/main/java/com/danielagapov/spawn/Mappers/FetchFriendRequestMapper.java
+++ b/src/main/java/com/danielagapov/spawn/Mappers/FetchFriendRequestMapper.java
@@ -9,4 +9,9 @@ public class FetchFriendRequestMapper {
         User sender = friendRequest.getSender();
         return new FetchFriendRequestDTO(friendRequest.getId(), UserMapper.toDTO(sender), mutualFriendCount);
     }
+    
+    public static FetchFriendRequestDTO toDTOForSentRequest(FriendRequest friendRequest, int mutualFriendCount) {
+        User receiver = friendRequest.getReceiver();
+        return new FetchFriendRequestDTO(friendRequest.getId(), UserMapper.toDTO(receiver), mutualFriendCount);
+    }
 }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequest/FriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequest/FriendRequestService.java
@@ -219,13 +219,16 @@ public class FriendRequestService implements IFriendRequestService {
                     cacheManager.getCache("recommendedFriends").evict(sender.getId());
                     cacheManager.getCache("recommendedFriends").evict(receiver.getId());
                 }
+                
+                repository.deleteById(id);
+                logger.info("Friend request deleted successfully");
             } else {
-                logger.info("Deleting friend request with ID: " + id + " (request details not available)");
+                logger.info("Friend request with ID: " + id + " was already deleted or does not exist");
             }
-
-            repository.deleteById(id);
-            logger.info("Friend request deleted successfully");
         } catch (DataAccessException e) {
+            logger.error("Error deleting friend request with ID: " + id + ": " + e.getMessage());
+            throw e;
+        } catch (Exception e) {
             logger.error("Error deleting friend request with ID: " + id + ": " + e.getMessage());
             throw e;
         }

--- a/src/main/java/com/danielagapov/spawn/Services/FriendRequest/IFriendRequestService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/FriendRequest/IFriendRequestService.java
@@ -21,6 +21,7 @@ public interface IFriendRequestService {
     List<FetchFriendRequestDTO> convertFriendRequestsToFetchFriendRequests(List<CreateFriendRequestDTO> friendRequests);
 
     List<CreateFriendRequestDTO> getSentFriendRequestsByUserId(UUID userId);
+    List<FetchFriendRequestDTO> getSentFetchFriendRequestsByUserId(UUID userId);
     void deleteFriendRequestBetweenUsersIfExists(UUID senderId, UUID receiverId);
     
     /**

--- a/src/test/java/com/danielagapov/spawn/ServiceTests/FriendRequestServiceTests.java
+++ b/src/test/java/com/danielagapov/spawn/ServiceTests/FriendRequestServiceTests.java
@@ -156,10 +156,27 @@ class FriendRequestServiceTests {
     @Test
     void deleteFriendRequest_ShouldDeleteRequest_WhenValidId() {
         UUID friendRequestId = friendRequest.getId();
+        // Mock findById to return the friend request, so deleteById will be called
+        when(repository.findById(friendRequestId)).thenReturn(Optional.of(friendRequest));
 
         friendRequestService.deleteFriendRequest(friendRequestId);
 
+        verify(repository, times(1)).findById(friendRequestId);
         verify(repository, times(1)).deleteById(friendRequestId);
+    }
+
+    @Test
+    void deleteFriendRequest_ShouldNotThrowException_WhenFriendRequestNotFound() {
+        UUID friendRequestId = UUID.randomUUID();
+        // Mock findById to return empty, simulating friend request not found
+        when(repository.findById(friendRequestId)).thenReturn(Optional.empty());
+
+        // This should not throw an exception
+        assertDoesNotThrow(() -> friendRequestService.deleteFriendRequest(friendRequestId));
+        
+        verify(repository, times(1)).findById(friendRequestId);
+        // deleteById should not be called since friend request doesn't exist
+        verify(repository, never()).deleteById(friendRequestId);
     }
 
     @Test
@@ -177,6 +194,8 @@ class FriendRequestServiceTests {
     @Test
     void deleteFriendRequest_ShouldThrowException_WhenDataAccessExceptionOccurs() {
         UUID friendRequestId = friendRequest.getId();
+        // Mock findById to return the friend request, so deleteById will be called
+        when(repository.findById(friendRequestId)).thenReturn(Optional.of(friendRequest));
         doThrow(new DataAccessException("DB delete error") {
         }).when(repository).deleteById(friendRequestId);
 


### PR DESCRIPTION
Friend requests page will now have two sections: received (like usual) and sent, to see outgoing friend reqs. 

Plus, fixed a bug with 404 PUT requests to back-end with friend reqs, which I'm assuming was caused by repeatedly pressing "accept"? Not sure. 