### PR TITLE
Only treating active users as real ones for auth

### DIFF
--- a/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
+++ b/src/main/java/com/danielagapov/spawn/Services/OAuth/OAuthService.java
@@ -6,6 +6,7 @@ import com.danielagapov.spawn.DTOs.User.UserCreationDTO;
 import com.danielagapov.spawn.DTOs.User.UserDTO;
 import com.danielagapov.spawn.Enums.EntityType;
 import com.danielagapov.spawn.Enums.OAuthProvider;
+import com.danielagapov.spawn.Enums.UserStatus;
 import com.danielagapov.spawn.Exceptions.AccountAlreadyExistsException;
 import com.danielagapov.spawn.Exceptions.Base.BaseNotFoundException;
 import com.danielagapov.spawn.Exceptions.IncorrectProviderException;
@@ -59,7 +60,17 @@ public class OAuthService implements IOAuthService {
             if (existsByExternalId) {
                 logger.info("Existing user detected in makeUser, mapping already exists");
                 User existingUser = getMapping(externalUserId).getUser();
-                return UserMapper.toDTO(existingUser);
+                
+                // Only return existing user if they have completed account creation
+                if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                    logger.info("Returning existing active user");
+                    return UserMapper.toDTO(existingUser);
+                } else {
+                    logger.info("Found incomplete user account (status: " + existingUser.getStatus() + "). Allowing re-creation.");
+                    // Delete the incomplete user and their mapping to allow fresh creation
+                    userService.deleteUserById(existingUser.getId());
+                    // The mapping will be cascade deleted with the user
+                }
             }
             
             // Case 2: There's already a Spawn user with this email address, but no mapping with this external id
@@ -68,10 +79,22 @@ public class OAuthService implements IOAuthService {
             if (existsByEmail) {
                 logger.info("Existing user detected in makeUser, email already exists");
                 UserIdExternalIdMap externalIdMap = getMappingByUserEmail(user.getEmail());
-                return UserMapper.toDTO(externalIdMap.getUser());
+                User existingUser = externalIdMap.getUser();
+                
+                // Only return existing user if they have completed account creation
+                if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                    logger.info("Returning existing active user with different provider");
+                    return UserMapper.toDTO(existingUser);
+                } else {
+                    logger.info("Found incomplete user account with email (status: " + existingUser.getStatus() + "). Allowing re-creation.");
+                    // Delete the incomplete user and their mapping to allow fresh creation
+                    userService.deleteUserById(existingUser.getId());
+                    // The mapping will be cascade deleted with the user
+                }
             }
             
             // Case 3: This is a new user, neither the externalId nor the email exists in our database
+            // OR we deleted an incomplete user above
             // Save the user with profile picture
             UserDTO userDTO = userService.createAndSaveUserWithProfilePicture(user, profilePicture);
             
@@ -112,18 +135,33 @@ public class OAuthService implements IOAuthService {
         boolean existsByEmail = userService.existsByEmail(email);
         logger.info("User exists by externalId: " + existsByExternalId + ", exists by email: " + existsByEmail);
 
-        if (existsByExternalId) { // A Spawn account exists with this external id, return the associated `BaseUserDTO`
+        if (existsByExternalId) { // A Spawn account exists with this external id, check if it's fully active
             logger.info("Found existing user by external ID: " + externalUserId);
             User user = getMapping(externalUserId).getUser();
-            BaseUserDTO userDTO = UserMapper.toDTO(user);
-            logger.info("Returning user with ID: " + userDTO.getId() + " and username: " + userDTO.getUsername());
-            return Optional.of(userDTO);
-        } else if (existsByEmail) { // A Spawn account exists with this email but not with the external id which indicates a sign-in with incorrect provider
-            logger.info("Found existing user by email but not by external ID. This indicates an incorrect provider login attempt.");
+            
+            // Only return the user if they have completed the account creation process
+            if (user.getStatus() == UserStatus.ACTIVE) {
+                BaseUserDTO userDTO = UserMapper.toDTO(user);
+                logger.info("Returning active user with ID: " + userDTO.getId() + " and username: " + userDTO.getUsername());
+                return Optional.of(userDTO);
+            } else {
+                logger.info("Found user by external ID but account is not active (status: " + user.getStatus() + "). Allowing re-completion of account creation.");
+                return Optional.empty();
+            }
+        } else if (existsByEmail) { // A Spawn account exists with this email but not with the external id
+            logger.info("Found existing user by email but not by external ID.");
             UserIdExternalIdMap externalIdMap = getMappingByUserEmail(email);
-            String provider = String.valueOf(externalIdMap.getProvider()).equals("google") ? "Google" : "Apple";
-            logger.info("Expected provider for this email: " + provider);
-            throw new IncorrectProviderException("The email: " + email + " is already associated to a " + provider + " account. Please login through " + provider + " instead");
+            User user = externalIdMap.getUser();
+            
+            // Only throw provider exception if the user has completed account creation
+            if (user.getStatus() == UserStatus.ACTIVE) {
+                String provider = String.valueOf(externalIdMap.getProvider()).equals("google") ? "Google" : "Apple";
+                logger.info("Expected provider for this email: " + provider);
+                throw new IncorrectProviderException("The email: " + email + " is already associated to a " + provider + " account. Please login through " + provider + " instead");
+            } else {
+                logger.info("Found user by email but account is not active (status: " + user.getStatus() + "). Allowing re-completion of account creation.");
+                return Optional.empty();
+            }
         } else { // No account exists for this external id or email
             logger.info("No existing user found for external ID: " + externalUserId + " or email: " + email);
             return Optional.empty();
@@ -191,16 +229,37 @@ public class OAuthService implements IOAuthService {
 
                 // Case 1: There's already a mapping for this externalId
                 if (existsByExternalId) {
-                    logger.info("Existing user detected in makeUser, mapping already exists");
-                    throw new AccountAlreadyExistsException("External ID already exists");
+                    logger.info("Existing user detected in checkOAuthRegistration, mapping already exists");
+                    User existingUser = getMapping(externalUserId).getUser();
+                    
+                    // Only throw exception if user has completed account creation
+                    if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                        throw new AccountAlreadyExistsException("External ID already exists");
+                    } else {
+                        logger.info("Found incomplete user account (status: " + existingUser.getStatus() + "). Allowing re-registration.");
+                        // Delete the incomplete user and their mapping to allow fresh registration
+                        userService.deleteUserById(existingUser.getId());
+                        // The mapping will be cascade deleted with the user
+                    }
                 }
 
                 // Case 2: There's already a Spawn user with this email address, but no mapping with this external id
                 // In this case, the user signed in with a different provider initially, so we should not allow creation
                 // with this provider
                 if (existsByEmail) {
-                    logger.info("Existing user detected in makeUser, email already exists");
-                    throw new IncorrectProviderException("Email already exists for a " + provider + " account. Please login through " + provider + " instead");
+                    logger.info("Existing user detected in checkOAuthRegistration, email already exists");
+                    UserIdExternalIdMap externalIdMap = getMappingByUserEmail(email);
+                    User existingUser = externalIdMap.getUser();
+                    
+                    // Only throw exception if user has completed account creation
+                    if (existingUser.getStatus() == UserStatus.ACTIVE) {
+                        throw new IncorrectProviderException("Email already exists for a " + provider + " account. Please login through " + provider + " instead");
+                    } else {
+                        logger.info("Found incomplete user account with email (status: " + existingUser.getStatus() + "). Allowing re-registration.");
+                        // Delete the incomplete user and their mapping to allow fresh registration
+                        userService.deleteUserById(existingUser.getId());
+                        // The mapping will be cascade deleted with the user
+                    }
                 }
 
                 // Case 3: This is a new user, neither the externalId nor the email exists in our database


### PR DESCRIPTION
This was to fix the following issue:

If I don't complete the account creation process, say I sign in through google, but don't fully make the user, don't save that user in the database, or at least don't stop someone from completing the account creation process. 

For example, like what I was saying, if someone clicks "continue with google" -> signs in -> doesn't complete name, username, etc. -> closes app -> continues with google again to create account again -> don't tell them the account already exists. 